### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,19 +440,19 @@ A few methods are currently supported only on iOS/Android SDKs:
 
 * Push Registration
 
-The method `mpInstance.logPushRegistration()` accepts two parameters. For Android, provide both `pushToken` and `senderId`. For iOS, provide the push token in the first parameter, and simply pass `null` for the second parameter
+    The method `mpInstance.logPushRegistration()` accepts two parameters. For Android, provide both `pushToken` and `senderId`. For iOS, provide the push token in the first parameter, and simply pass `null` for the second parameter
 
-### Android
+    ### Android
 
-```dart
-mpInstance.logPushRegistration(pushToken, senderId);
-```
+    ```dart
+    mpInstance.logPushRegistration(pushToken, senderId);
+    ```
 
-### iOS
+    ### iOS
 
-```dart
-mpInstance.logPushRegistration(pushToken, null);
-```
+    ```dart
+    mpInstance.logPushRegistration(pushToken, null);
+    ```
 
 
 # License


### PR DESCRIPTION
# Summary

It appears that the markdown readers for Github and Pub.dev differ, and so the checkboxes inside of the `Supported Feature` table breaks on pub.dev.  - https://pub.dev/packages/mparticle_flutter_sdk

Also there are some broken code samples that this PR fixes.