### PR TITLE
feat: Add Commerce Event Support for Core and iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -123,11 +123,11 @@ class _MyAppState extends State<MyApp> {
                   customFlags: {'flag1': 'flagValue1'});
             }),
             buildButton('Log Commerce - Product', () {
-              final Product product1 = Product('Orange', '123abc', 2, 1.3);
-              final Product product2 = Product('Apple', '456abc', 4, 2.2);
+              final Product product1 = Product('Orange', '123abc', 2.4, 1);
+              final Product product2 = Product('Apple', '456abc', 4.1, 2);
               final TransactionAttributes transactionAttributes =
-                  TransactionAttributes('affiliation', '12412342', 1.34, 43.232,
-                      242.2323, '123456');
+                  TransactionAttributes('123456', 'affiliation', '12412342',
+                      1.34, 43.232, 242.2323);
               mpInstance?.logCommerceEvent(
                   productActionType: ProductActionType.Purchase,
                   products: [product1.toJson(), product2.toJson()],
@@ -148,11 +148,11 @@ class _MyAppState extends State<MyApp> {
                   screenName: 'One Click Purchase');
             }),
             buildButton('Log Commerce - Impression', () {
-              final Product product1 = Product('Orange', '123abc', 2, 1.3);
-              final Product product2 = Product('Apple', '456abc', 4, 2.2);
+              final Product product1 = Product('Orange', '123abc', 2.4, 1);
+              final Product product2 = Product('Apple', '456abc', 4.1, 2);
               final Impression impression1 =
                   Impression('produce', [product1, product2]);
-              final Impression impression2 = Impression('citris', [product1]);
+              final Impression impression2 = Impression('citrus', [product1]);
               mpInstance?.logCommerceEvent(
                   impressions: [impression1.toJson(), impression2.toJson()],
                   currency: 'US',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,7 +130,7 @@ class _MyAppState extends State<MyApp> {
                       1.34, 43.232, 242.2323);
               mpInstance?.logCommerceEvent(
                   productActionType: ProductActionType.Purchase,
-                  products: [product1.toJson(), product2.toJson()],
+                  products: [product1, product2],
                   transactionAttributes: transactionAttributes,
                   currency: 'US',
                   screenName: 'One Click Purchase');
@@ -143,7 +143,7 @@ class _MyAppState extends State<MyApp> {
 
               mpInstance?.logCommerceEvent(
                   promotionActionType: PromotionActionType.View,
-                  promotions: [promotion1.toJson(), promotion2.toJson()],
+                  promotions: [promotion1, promotion2],
                   currency: 'US',
                   screenName: 'One Click Purchase');
             }),
@@ -154,7 +154,7 @@ class _MyAppState extends State<MyApp> {
                   Impression('produce', [product1, product2]);
               final Impression impression2 = Impression('citrus', [product1]);
               mpInstance?.logCommerceEvent(
-                  impressions: [impression1.toJson(), impression2.toJson()],
+                  impressions: [impression1, impression2],
                   currency: 'US',
                   screenName: 'One Click Purchase');
             }),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,12 @@ import 'dart:async';
 
 import 'package:mparticle_flutter_sdk/mparticle_flutter_sdk.dart';
 import 'package:mparticle_flutter_sdk/events/event_type.dart';
+import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/promotion.dart';
+import 'package:mparticle_flutter_sdk/events/product.dart';
+import 'package:mparticle_flutter_sdk/events/impression.dart';
+import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_type.dart';
 import 'package:mparticle_flutter_sdk/kits/kits.dart';
 import 'package:mparticle_flutter_sdk/identity/alias_request.dart';
@@ -115,6 +121,42 @@ class _MyAppState extends State<MyApp> {
                   eventName: 'Screen event logged',
                   customAttributes: {'key1': 'value1'},
                   customFlags: {'flag1': 'flagValue1'});
+            }),
+            buildButton('Log Commerce - Product', () {
+              final Product product1 = Product('Orange', '123abc', 2, 1.3);
+              final Product product2 = Product('Apple', '456abc', 4, 2.2);
+              final TransactionAttributes transactionAttributes =
+                  TransactionAttributes('affiliation', '12412342', 1.34, 43.232,
+                      242.2323, '123456');
+              mpInstance?.logCommerceEvent(
+                  productActionType: ProductActionType.Purchase,
+                  products: [product1.toJson(), product2.toJson()],
+                  transactionAttributes: transactionAttributes,
+                  currency: 'US',
+                  screenName: 'One Click Purchase');
+            }),
+            buildButton('Log Commerce - Promotion', () {
+              final Promotion promotion1 =
+                  Promotion('12312', 'Jennifer Slater', 'BOGO Bonanza', 'top');
+              final Promotion promotion2 =
+                  Promotion('15632', 'Gregor Roman', 'Eco Living', 'mid');
+
+              mpInstance?.logCommerceEvent(
+                  promotionActionType: PromotionActionType.View,
+                  promotions: [promotion1.toJson(), promotion2.toJson()],
+                  currency: 'US',
+                  screenName: 'One Click Purchase');
+            }),
+            buildButton('Log Commerce - Impression', () {
+              final Product product1 = Product('Orange', '123abc', 2, 1.3);
+              final Product product2 = Product('Apple', '456abc', 4, 2.2);
+              final Impression impression1 =
+                  Impression('produce', [product1, product2]);
+              final Impression impression2 = Impression('citris', [product1]);
+              mpInstance?.logCommerceEvent(
+                  impressions: [impression1.toJson(), impression2.toJson()],
+                  currency: 'US',
+                  screenName: 'One Click Purchase');
             }),
             buildButton('Log Error', () {
               mpInstance?.logError(

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -244,6 +244,121 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
                 }
             }
         }
+    case "logCommerceEvent":
+        if let callArguments = call.arguments as? [String: Any] {
+            let event: MPCommerceEvent
+            if let rawActionType = callArguments["productActionType"] as? NSNumber,
+               let actionType = MPCommerceEventAction(rawValue:UInt(truncating: rawActionType)) {
+                event = MPCommerceEvent.init(action: actionType)
+            } else if let rawActionType = callArguments["promotionActionType"] as? NSNumber,
+                      let actionType = MPPromotionAction(rawValue:UInt(truncating: rawActionType)) {
+                let container = MPPromotionContainer.init(action: actionType, promotion: nil)
+
+                if let rawPromotions = callArguments["promotions"] as? [[String: Any]] {
+                    for rawPromotion in rawPromotions {
+                        let promotion = MPPromotion.init()
+                        promotion.promotionId = rawPromotion["promotionId"] as? String
+                        promotion.creative = rawPromotion["creative"] as? String
+                        promotion.name = rawPromotion["name"] as? String
+                        promotion.position = rawPromotion["position"] as? String
+
+                        container .addPromotion(promotion)
+                    }
+                }
+
+                event = MPCommerceEvent.init(promotionContainer: container)
+            } else {
+                event = MPCommerceEvent.init(impressionName: nil, product: nil)
+            }
+            // Optional Products on Commerce Event
+            if let rawProducts = callArguments["products"] as? [[String: Any]] {
+                for rawProduct in rawProducts {
+                    if let name = rawProduct["name"] as? String,
+                       let sku = rawProduct["sku"] as? String,
+                       let quantity = rawProduct["quantity"] as? NSNumber,
+                       let price = rawProduct["price"] as? NSNumber {
+                        let newProduct = MPProduct.init(name: name,
+                                                        sku: sku,
+                                                        quantity: quantity,
+                                                        price: price)
+                        event.addProduct(newProduct)
+                    }
+                }
+            }
+
+            // Optional Transaction Attributes
+            if let rawTransactionAttributes = callArguments["transactionAttributes"] as? [String: Any] {
+                let attributes = MPTransactionAttributes.init()
+                if let affiliation = rawTransactionAttributes["affiliation"] as? String {
+                    attributes.affiliation = affiliation
+                }
+                if let couponCode = rawTransactionAttributes["couponCode"] as? String {
+                    attributes.couponCode = couponCode
+                }
+                if let shipping = rawTransactionAttributes["shipping"] as? NSNumber {
+                    attributes.shipping = shipping
+                }
+                if let tax = rawTransactionAttributes["tax"] as? NSNumber {
+                    attributes.tax = tax
+                }
+                if let revenue = rawTransactionAttributes["revenue"] as? NSNumber {
+                    attributes.revenue = revenue
+                }
+                if let transactionId = rawTransactionAttributes["transactionId"] as? String {
+                    attributes.transactionId = transactionId
+                }
+
+                event.transactionAttributes = attributes
+            }
+
+            if let rawImpressions = callArguments["impressions"] as? [[String: Any]] {
+                for rawImpression in rawImpressions {
+                    if let listName = rawImpression["impressionListName"] as? String,
+                       let rawProducts = rawImpression["products"] as? [[String: Any]] {
+                        for rawProduct in rawProducts {
+                            if let name = rawProduct["name"] as? String,
+                               let sku = rawProduct["sku"] as? String,
+                               let quantity = rawProduct["quantity"] as? NSNumber,
+                               let price = rawProduct["price"] as? NSNumber {
+                                let newProduct = MPProduct.init(name: name,
+                                                                sku: sku,
+                                                                quantity: quantity,
+                                                                price: price)
+                                event.addImpression(newProduct, listName: listName)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Optionable Properties on MPCommerceEvent
+            if let checkoutOptions = callArguments["checkoutOptions"] as? String {
+                event.checkoutOptions = checkoutOptions
+            }
+            if let currency = callArguments["currency"] as? String {
+                event.currency = currency
+            }
+            if let productListName = callArguments["productListName"] as? String {
+                event.productListName = productListName
+            }
+            if let productListSource = callArguments["productListSource"] as? String {
+                event.productListSource = productListSource
+            }
+            if let screenName = callArguments["screenName"] as? String {
+                event.screenName = screenName
+            }
+            // ??? checkoutStep is deprecated for iOS
+            if let checkoutStep = callArguments["checkoutStep"] as? NSNumber {
+                event.checkoutStep = checkoutStep.intValue
+            }
+            if let nonInteractive = callArguments["nonInteractive"] as? Bool {
+                event.nonInteractive = nonInteractive
+            }
+
+            MParticle.sharedInstance().logEvent(event)
+        } else {
+            print("Incorrect argument for \(call.method) iOS method")
+        }
     default:
         print("mParticle flutter SDK for iOS does not support \(call.method)")
     }

--- a/lib/events/impression.dart
+++ b/lib/events/impression.dart
@@ -1,0 +1,24 @@
+import 'package:mparticle_flutter_sdk/events/product.dart';
+
+class Impression {
+  Impression(this.impressionListName, this.products);
+
+  final String impressionListName;
+  final List<Product> products;
+
+  static Impression fromJson(dynamic json) {
+    return Impression(json['impressionListName'] as String,
+        json['products'] as List<Product>);
+  }
+
+  Map<String, dynamic> toJson() {
+    List<dynamic> productsJSON = [];
+    for (var product in this.products) {
+      productsJSON.add(product.toJson());
+    }
+    return {
+      'impressionListName': this.impressionListName,
+      'products': productsJSON
+    };
+  }
+}

--- a/lib/events/impression.dart
+++ b/lib/events/impression.dart
@@ -6,13 +6,13 @@ class Impression {
   final String impressionListName;
   final List<Product> products;
 
-  static Impression fromJson(dynamic json) {
+  static Impression fromJson(Map<String, dynamic> json) {
     return Impression(json['impressionListName'] as String,
         json['products'] as List<Product>);
   }
 
   Map<String, dynamic> toJson() {
-    List<dynamic> productsJSON = [];
+    List<Map<String, dynamic>> productsJSON = [];
     for (var product in this.products) {
       productsJSON.add(product.toJson());
     }

--- a/lib/events/product.dart
+++ b/lib/events/product.dart
@@ -1,0 +1,22 @@
+class Product {
+  Product(this.name, this.sku, this.quantity, this.price);
+
+  final String name;
+  final String sku;
+  final int quantity;
+  final double price;
+
+  static Product fromJson(dynamic json) {
+    return Product(json['name'] as String, json['sku'] as String,
+        json['quantity'] as int, json['price'] as double);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': this.name,
+      'sku': this.sku,
+      'quantity': this.quantity,
+      'price': this.price
+    };
+  }
+}

--- a/lib/events/product.dart
+++ b/lib/events/product.dart
@@ -1,9 +1,9 @@
 class Product {
-  Product(this.name, this.sku, this.price, this.quantity);
+  Product(this.name, this.sku, this.price, [this.quantity]);
 
   final String name;
   final String sku;
-  final int quantity;
+  final int? quantity;
   final double price;
 
   static Product fromJson(Map<String, dynamic> json) {

--- a/lib/events/product.dart
+++ b/lib/events/product.dart
@@ -1,14 +1,14 @@
 class Product {
-  Product(this.name, this.sku, this.quantity, this.price);
+  Product(this.name, this.sku, this.price, this.quantity);
 
   final String name;
   final String sku;
   final int quantity;
   final double price;
 
-  static Product fromJson(dynamic json) {
+  static Product fromJson(Map<String, dynamic> json) {
     return Product(json['name'] as String, json['sku'] as String,
-        json['quantity'] as int, json['price'] as double);
+        json['price'] as double, json['quantity'] as int);
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/events/product_action_type.dart
+++ b/lib/events/product_action_type.dart
@@ -1,0 +1,13 @@
+/// Contains the Product Action types for logging mParticle commerce product events
+enum ProductActionType {
+  AddToCart,
+  RemoveFromCart,
+  AddToWishList,
+  RemoveFromWishlist,
+  Checkout,
+  CheckoutOptions,
+  Click,
+  ViewDetail,
+  Purchase,
+  Refund
+}

--- a/lib/events/promotion.dart
+++ b/lib/events/promotion.dart
@@ -1,0 +1,22 @@
+class Promotion {
+  Promotion(this.promotionId, this.creative, this.name, this.position);
+
+  final String? promotionId;
+  final String? creative;
+  final String? name;
+  final String? position;
+
+  static Promotion fromJson(dynamic json) {
+    return Promotion(json['promotionId'] as String, json['creative'] as String,
+        json['name'] as String, json['position'] as String);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'promotionId': this.promotionId,
+      'creative': this.creative,
+      'name': this.name,
+      'position': this.position
+    };
+  }
+}

--- a/lib/events/promotion.dart
+++ b/lib/events/promotion.dart
@@ -1,12 +1,12 @@
 class Promotion {
-  Promotion(this.promotionId, this.creative, this.name, this.position);
+  Promotion(this.promotionId, [this.creative, this.name, this.position]);
 
-  final String? promotionId;
+  final String promotionId;
   final String? creative;
   final String? name;
   final String? position;
 
-  static Promotion fromJson(dynamic json) {
+  static Promotion fromJson(Map<String, dynamic> json) {
     return Promotion(json['promotionId'] as String, json['creative'] as String,
         json['name'] as String, json['position'] as String);
   }

--- a/lib/events/promotion_action_type.dart
+++ b/lib/events/promotion_action_type.dart
@@ -1,0 +1,2 @@
+/// Contains the event types for logging mParticle custom events
+enum PromotionActionType { Click, View }

--- a/lib/events/transaction_attributes.dart
+++ b/lib/events/transaction_attributes.dart
@@ -1,0 +1,32 @@
+class TransactionAttributes {
+  TransactionAttributes(this.affiliation, this.couponCode, this.shipping,
+      this.tax, this.revenue, this.transactionId);
+
+  final String? affiliation;
+  final String? couponCode;
+  final double? shipping;
+  final double? tax;
+  final double? revenue;
+  final String? transactionId;
+
+  static TransactionAttributes fromJson(dynamic json) {
+    return TransactionAttributes(
+        json['affiliation'] as String,
+        json['couponCode'] as String,
+        json['shipping'] as double,
+        json['tax'] as double,
+        json['revenue'] as double,
+        json['transactionId'] as String);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'affiliation': this.affiliation,
+      'couponCode': this.couponCode,
+      'shipping': this.shipping,
+      'tax': this.tax,
+      'revenue': this.revenue,
+      'transactionId': this.transactionId
+    };
+  }
+}

--- a/lib/events/transaction_attributes.dart
+++ b/lib/events/transaction_attributes.dart
@@ -1,32 +1,36 @@
 class TransactionAttributes {
-  TransactionAttributes(this.affiliation, this.couponCode, this.shipping,
-      this.tax, this.revenue, this.transactionId);
+  TransactionAttributes(this.transactionId,
+      [this.affiliation,
+      this.couponCode,
+      this.shipping,
+      this.tax,
+      this.revenue]);
 
+  final String transactionId;
   final String? affiliation;
   final String? couponCode;
   final double? shipping;
   final double? tax;
   final double? revenue;
-  final String? transactionId;
 
-  static TransactionAttributes fromJson(dynamic json) {
+  static TransactionAttributes fromJson(Map<String, dynamic> json) {
     return TransactionAttributes(
+        json['transactionId'] as String,
         json['affiliation'] as String,
         json['couponCode'] as String,
         json['shipping'] as double,
         json['tax'] as double,
-        json['revenue'] as double,
-        json['transactionId'] as String);
+        json['revenue'] as double);
   }
 
   Map<String, dynamic> toJson() {
     return {
+      'transactionId': this.transactionId,
       'affiliation': this.affiliation,
       'couponCode': this.couponCode,
       'shipping': this.shipping,
       'tax': this.tax,
-      'revenue': this.revenue,
-      'transactionId': this.transactionId
+      'revenue': this.revenue
     };
   }
 }

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -5,6 +5,12 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:mparticle_flutter_sdk/src/identity/identity_helpers.dart';
 import 'package:mparticle_flutter_sdk/events/event_type.dart';
+import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/promotion.dart';
+import 'package:mparticle_flutter_sdk/events/product.dart';
+import 'package:mparticle_flutter_sdk/events/impression.dart';
+import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_type.dart';
 import 'package:mparticle_flutter_sdk/apple/authorization_status.dart';
 import 'package:mparticle_flutter_sdk/src/user.dart';
@@ -60,6 +66,71 @@ class MparticleFlutterSdk {
     required int kit,
   }) async {
     return await _channel.invokeMethod('isKitActive', {'kitId': kit});
+  }
+
+  /// Logs a product commerce event with an [productActionType], a promotion commerce event with a [eventType], and an impression commerce event if neither of the prior are implemented.
+  Future<void> logCommerceEvent({
+    ProductActionType? productActionType,
+    PromotionActionType? promotionActionType,
+    List<Map<String, dynamic>>? promotions,
+    List<Map<String, dynamic>>? products,
+    List<Map<String, dynamic>>? impressions,
+    TransactionAttributes? transactionAttributes,
+    String? checkoutOptions,
+    String? currency,
+    String? productListName,
+    String? productListSource,
+    String? screenName,
+    int? checkoutStep,
+    bool? nonInteractive,
+  }) async {
+    if (productActionType != null) {
+      return await _channel.invokeMethod('logCommerceEvent', {
+        'productActionType':
+            ProductActionType.values.indexOf(productActionType),
+        'products': products,
+        'promotions': promotions,
+        'impressions': impressions,
+        'transactionAttributes': transactionAttributes?.toJson(),
+        'checkoutOptions': checkoutOptions,
+        'currency': currency,
+        'productListName': productListName,
+        'productListSource': productListSource,
+        'screenName': screenName,
+        'checkoutStep': checkoutStep,
+        'nonInteractive': nonInteractive
+      });
+    } else if (promotionActionType != null) {
+      return await _channel.invokeMethod('logCommerceEvent', {
+        'promotionActionType':
+            PromotionActionType.values.indexOf(promotionActionType),
+        'products': products,
+        'promotions': promotions,
+        'impressions': impressions,
+        'transactionAttributes': transactionAttributes,
+        'checkoutOptions': checkoutOptions,
+        'currency': currency,
+        'productListName': productListName,
+        'productListSource': productListSource,
+        'screenName': screenName,
+        'checkoutStep': checkoutStep,
+        'nonInteractive': nonInteractive
+      });
+    } else {
+      return await _channel.invokeMethod('logCommerceEvent', {
+        'products': products,
+        'promotions': promotions,
+        'impressions': impressions,
+        'transactionAttributes': transactionAttributes,
+        'checkoutOptions': checkoutOptions,
+        'currency': currency,
+        'productListName': productListName,
+        'productListSource': productListSource,
+        'screenName': screenName,
+        'checkoutStep': checkoutStep,
+        'nonInteractive': nonInteractive
+      });
+    }
   }
 
   /// Logs an error event with an [eventName] and [customAttributes].

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -3,6 +3,9 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:mparticle_flutter_sdk/events/impression.dart';
+import 'package:mparticle_flutter_sdk/events/product.dart';
+import 'package:mparticle_flutter_sdk/events/promotion.dart';
 import 'package:mparticle_flutter_sdk/src/identity/identity_helpers.dart';
 import 'package:mparticle_flutter_sdk/events/event_type.dart';
 import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
@@ -69,10 +72,12 @@ class MparticleFlutterSdk {
   Future<void> logCommerceEvent({
     ProductActionType? productActionType,
     PromotionActionType? promotionActionType,
-    List<Map<String, dynamic>>? promotions,
-    List<Map<String, dynamic>>? products,
-    List<Map<String, dynamic>>? impressions,
+    List<Promotion>? promotions,
+    List<Product>? products,
+    List<Impression>? impressions,
     TransactionAttributes? transactionAttributes,
+    Map<String, String?>? customAttributes,
+    Map<String, dynamic>? customFlags,
     String? checkoutOptions,
     String? currency,
     String? productListName,
@@ -81,11 +86,32 @@ class MparticleFlutterSdk {
     int? checkoutStep,
     bool? nonInteractive,
   }) async {
+    var promotionsJSON = [];
+    if (promotions != null) {
+      for (var promotion in promotions) {
+        promotionsJSON.add(promotion.toJson());
+      }
+    }
+    var productsJSON = [];
+    if (products != null) {
+      for (var product in products) {
+        productsJSON.add(product.toJson());
+      }
+    }
+    var impressionsJSON = [];
+    if (impressions != null) {
+      for (var impression in impressions) {
+        impressionsJSON.add(impression.toJson());
+      }
+    }
+
     var commerceEvent = {
-      'products': products,
-      'promotions': promotions,
-      'impressions': impressions,
+      'products': productsJSON,
+      'promotions': promotionsJSON,
+      'impressions': impressionsJSON,
       'transactionAttributes': transactionAttributes?.toJson(),
+      'customAttributes': customAttributes,
+      'customFlags': customFlags,
       'checkoutOptions': checkoutOptions,
       'currency': currency,
       'productListName': productListName,
@@ -101,7 +127,8 @@ class MparticleFlutterSdk {
       commerceEvent['promotionActionType'] =
           PromotionActionType.values.indexOf(promotionActionType);
     }
-    return await _channel.invokeMethod('logCommerceEvent', commerceEvent);
+    return await _channel
+        .invokeMethod('logCommerceEvent', {"commerceEvent": commerceEvent});
   }
 
   /// Logs an error event with an [eventName] and [customAttributes].

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -7,9 +7,6 @@ import 'package:mparticle_flutter_sdk/src/identity/identity_helpers.dart';
 import 'package:mparticle_flutter_sdk/events/event_type.dart';
 import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
 import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
-import 'package:mparticle_flutter_sdk/events/promotion.dart';
-import 'package:mparticle_flutter_sdk/events/product.dart';
-import 'package:mparticle_flutter_sdk/events/impression.dart';
 import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_type.dart';
 import 'package:mparticle_flutter_sdk/apple/authorization_status.dart';
@@ -84,53 +81,27 @@ class MparticleFlutterSdk {
     int? checkoutStep,
     bool? nonInteractive,
   }) async {
+    var commerceEvent = {
+      'products': products,
+      'promotions': promotions,
+      'impressions': impressions,
+      'transactionAttributes': transactionAttributes?.toJson(),
+      'checkoutOptions': checkoutOptions,
+      'currency': currency,
+      'productListName': productListName,
+      'productListSource': productListSource,
+      'screenName': screenName,
+      'checkoutStep': checkoutStep,
+      'nonInteractive': nonInteractive
+    };
     if (productActionType != null) {
-      return await _channel.invokeMethod('logCommerceEvent', {
-        'productActionType':
-            ProductActionType.values.indexOf(productActionType),
-        'products': products,
-        'promotions': promotions,
-        'impressions': impressions,
-        'transactionAttributes': transactionAttributes?.toJson(),
-        'checkoutOptions': checkoutOptions,
-        'currency': currency,
-        'productListName': productListName,
-        'productListSource': productListSource,
-        'screenName': screenName,
-        'checkoutStep': checkoutStep,
-        'nonInteractive': nonInteractive
-      });
+      commerceEvent['productActionType'] =
+          ProductActionType.values.indexOf(productActionType);
     } else if (promotionActionType != null) {
-      return await _channel.invokeMethod('logCommerceEvent', {
-        'promotionActionType':
-            PromotionActionType.values.indexOf(promotionActionType),
-        'products': products,
-        'promotions': promotions,
-        'impressions': impressions,
-        'transactionAttributes': transactionAttributes,
-        'checkoutOptions': checkoutOptions,
-        'currency': currency,
-        'productListName': productListName,
-        'productListSource': productListSource,
-        'screenName': screenName,
-        'checkoutStep': checkoutStep,
-        'nonInteractive': nonInteractive
-      });
-    } else {
-      return await _channel.invokeMethod('logCommerceEvent', {
-        'products': products,
-        'promotions': promotions,
-        'impressions': impressions,
-        'transactionAttributes': transactionAttributes,
-        'checkoutOptions': checkoutOptions,
-        'currency': currency,
-        'productListName': productListName,
-        'productListSource': productListSource,
-        'screenName': screenName,
-        'checkoutStep': checkoutStep,
-        'nonInteractive': nonInteractive
-      });
+      commerceEvent['promotionActionType'] =
+          PromotionActionType.values.indexOf(promotionActionType);
     }
+    return await _channel.invokeMethod('logCommerceEvent', commerceEvent);
   }
 
   /// Logs an error event with an [eventName] and [customAttributes].


### PR DESCRIPTION
# Summary

Added support for Product, Promotion, and Impression Commerce Events and implemented on iOS. This also adds new buttons to the sample app to test each type of commerce event.

TP: 70881
