### PR TITLE
feat: Add Android getAttributes implementation

### DIFF
--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -124,9 +124,11 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         ?.entries
         ?.fold(JSONObject()) { jsonObj, entry ->
           val value = JSONObject().apply {
-            put("link", entry.value.link)
-            put("linkParameters",(entry.value.parameters ?: JSONObject()).toString())
-            put("kitId", entry.value.serviceProviderId.toString())
+            entry.value?.let { attributionResult ->
+              put("link", attributionResult.link)
+              put("linkParameters", (attributionResult.parameters ?: JSONObject()).toString())
+              put("kitId", attributionResult.serviceProviderId.toString())
+            }
           }
           jsonObj.put(entry.key.toString(), value)
         }.let { result.success((it ?: JSONObject()).toString()) }

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -124,6 +124,7 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         ?.entries
         ?.fold(JSONObject()) { jsonObj, entry ->
           val value = JSONObject().apply {
+            put("link", entry.value.link)
             put("linkParameters",(entry.value.parameters ?: JSONObject()).toString())
             put("kitId", entry.value.serviceProviderId.toString())
           }

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -119,6 +119,16 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         } ?: result.error(TAG, "Missing attributeKey", null)
       }
       "aliasUsers" -> this.aliasUsers(call, result)
+      "getAttributions" ->
+        MParticle.getInstance()?.attributionResults
+        ?.entries
+        ?.fold(JSONObject()) { jsonObj, entry ->
+          val value = JSONObject().apply {
+            put("linkParameters",(entry.value.parameters ?: JSONObject()).toString())
+            put("kitId", entry.value.serviceProviderId.toString())
+          }
+          jsonObj.put(entry.key.toString(), value)
+        }.let { result.success((it ?: JSONObject()).toString()) }
       else -> {
         result.notImplemented()
       }


### PR DESCRIPTION
# Summary

Add `getAttributions()` implementation for Android. This one is pretty straightforward. For the nullable field `linkParameters`, we will send an empty Json String instead of `null`. 

Smoke tested with:
- no attributions 
    - returns empty Json object `"{}"` to the Flutter layer
- Adjust Kit with attribution
    - returns `{"68":{"linkParameters":"{"tracker_token":"qtjh2jv","tracker_name":"Organic","network":"Organic","campaign":"","adgroup":"","creative":"","click_label":"","adid":"52eec0cb17cd177d2f9e0b64646c779f"}","kitId":"68"}}` to the Flutter layer
