### PR TITLE
refactor: CommerceEvent class

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:mparticle_flutter_sdk/mparticle_flutter_sdk.dart';
 import 'package:mparticle_flutter_sdk/events/event_type.dart';
+import 'package:mparticle_flutter_sdk/events/commerce_event.dart';
 import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
 import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
 import 'package:mparticle_flutter_sdk/events/promotion.dart';
@@ -128,12 +129,12 @@ class _MyAppState extends State<MyApp> {
               final TransactionAttributes transactionAttributes =
                   TransactionAttributes('123456', 'affiliation', '12412342',
                       1.34, 43.232, 242.2323);
-              mpInstance?.logCommerceEvent(
-                  productActionType: ProductActionType.Purchase,
-                  products: [product1, product2],
-                  transactionAttributes: transactionAttributes,
-                  currency: 'US',
-                  screenName: 'One Click Purchase');
+              CommerceEvent commerceEvent = new CommerceEvent.withProduct(ProductActionType.Purchase, product1)
+                ..products.add(product2)
+                ..transactionAttributes = transactionAttributes
+                ..currency = 'US'
+                ..screenName = 'One Click Purchase';
+              mpInstance?.logCommerceEvent(commerceEvent);
             }),
             buildButton('Log Commerce - Promotion', () {
               final Promotion promotion1 =
@@ -141,11 +142,11 @@ class _MyAppState extends State<MyApp> {
               final Promotion promotion2 =
                   Promotion('15632', 'Gregor Roman', 'Eco Living', 'mid');
 
-              mpInstance?.logCommerceEvent(
-                  promotionActionType: PromotionActionType.View,
-                  promotions: [promotion1, promotion2],
-                  currency: 'US',
-                  screenName: 'One Click Purchase');
+              CommerceEvent commerceEvent = CommerceEvent.withPromotion(PromotionActionType.View, promotion1)
+                ..promotions.add(promotion2)
+                ..currency = 'US'
+                ..screenName = 'OneClickPurchase';
+              mpInstance?.logCommerceEvent(commerceEvent);
             }),
             buildButton('Log Commerce - Impression', () {
               final Product product1 = Product('Orange', '123abc', 2.4, 1);
@@ -153,10 +154,11 @@ class _MyAppState extends State<MyApp> {
               final Impression impression1 =
                   Impression('produce', [product1, product2]);
               final Impression impression2 = Impression('citrus', [product1]);
-              mpInstance?.logCommerceEvent(
-                  impressions: [impression1, impression2],
-                  currency: 'US',
-                  screenName: 'One Click Purchase');
+              CommerceEvent commerceEvent = new CommerceEvent.withImpression(impression2)
+                  ..impressions.add(impression2)
+                  ..currency = 'US'
+                  ..screenName = 'One Click Purchase';
+              mpInstance?.logCommerceEvent(commerceEvent);
             }),
             buildButton('Log Error', () {
               mpInstance?.logError(

--- a/lib/events/commerce_event.dart
+++ b/lib/events/commerce_event.dart
@@ -1,0 +1,39 @@
+import 'package:mparticle_flutter_sdk/events/product.dart';
+import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/promotion.dart';
+import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
+
+import 'impression.dart';
+
+class CommerceEvent {
+
+  CommerceEvent.withProduct(this.productActionType, Product product): promotionActionType = null {
+    products.add(product);
+  }
+
+  CommerceEvent.withPromotion(this.promotionActionType, Promotion promotion) : productActionType = null {
+    promotions.add(promotion);
+  }
+
+
+  CommerceEvent.withImpression(Impression impression): promotionActionType = null, productActionType = null {
+    impressions.add(impression);
+  }
+
+  final ProductActionType? productActionType;
+  final PromotionActionType? promotionActionType;
+
+  final List<Promotion> promotions = [];
+  final List<Product> products = [];
+  final List<Impression> impressions = [];
+
+  TransactionAttributes? transactionAttributes;
+  String? checkoutOptions;
+  String? currency;
+  String? productListName;
+  String? productListSource;
+  String? screenName;
+  int? checkoutStep;
+  bool? nonInteractive;
+}

--- a/lib/src/commerce/commerce_helpers.dart
+++ b/lib/src/commerce/commerce_helpers.dart
@@ -1,0 +1,36 @@
+import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
+
+String productActionTypeString(ProductActionType productActionType) {
+  switch (productActionType) {
+    case ProductActionType.AddToCart:
+      return "add_to_cart";
+    case ProductActionType.RemoveFromCart:
+      return "remove_from_cart";
+    case ProductActionType.AddToWishList:
+      return "add_to_wishlist";
+    case ProductActionType.RemoveFromWishlist:
+      return "remove_from_wishlist";
+    case ProductActionType.Checkout:
+      return "checkout";
+    case ProductActionType.Click:
+      return "click";
+    case ProductActionType.ViewDetail:
+      return "view_detail";
+    case ProductActionType.Purchase:
+      return "purchase";
+    case ProductActionType.Refund:
+      return "refund";
+    case ProductActionType.CheckoutOptions:
+      return "checkout_option";
+  }
+}
+
+String promotionActionTypeString(PromotionActionType productActionType) {
+  switch (productActionType) {
+    case PromotionActionType.Click:
+      return "click";
+    case PromotionActionType.View:
+      return "view";
+  }
+}


### PR DESCRIPTION
# Summary

This is meant to be an improvement on the `logCommerceEvent({many})` endpoint. In the native SDKs and most of our others wrapper SDKs, we use a `CommerceEvent` object in the public API. This PR replaces that multi argument `logCommerceEvent` call with one that accepts a similar `CommerceEvent` instance.

The `CommerceEvent` constructors follow the same pattern as we do in other SDKs. Since overloaded constructors don't really exist in Dart we used "named constructors", as follows

`CommerceEvent.withProduct(ProductActionEnum, Product)`
`CommerceEvent.withPromotion(PromotionActionEnum, Promotion)`
`CommerceEvent.withImpression(Impression)`

Dart has a neat syntax for chaining calls for a receiver using the `..` notation. I left the `CommerceEvent` class fairly basic (just fields and the 3 constructors) since the pattern we've used elsewhere of having one giant constructor seemed like maybe a not great UX for as large an event like this one. A full sample initialization now looks like this:

```
Product product = //initialize
Product otherProduct = //initialize
TransactionAttrributes = //initialize
CommerceEvent commerceEvent = new CommerceEvent.withProduct(ProductActionType.Purchase, product)
                ..products.add(otherProduct)
                ..transactionAttributes = transactionAttributes
                ..currency = 'US'
                ..screenName = 'One Click Purchase';
```

>note: this is targeted at my commerce-android branch..there was one little change that would have been a conflict, so I left it built on top of it