### PR TITLE
fix: Add customAttributes and customFlags to CommerceEvent

### DIFF
--- a/lib/events/commerce_event.dart
+++ b/lib/events/commerce_event.dart
@@ -36,4 +36,7 @@ class CommerceEvent {
   String? screenName;
   int? checkoutStep;
   bool? nonInteractive;
+
+  Map<String, String?>? customAttributes;
+  Map<String, dynamic>? customFlags;
 }

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -82,7 +82,9 @@ class MparticleFlutterSdk {
       'productListSource': commerceEvent.productListSource,
       'screenName': commerceEvent.screenName,
       'checkoutStep': commerceEvent.checkoutStep,
-      'nonInteractive': commerceEvent.nonInteractive
+      'nonInteractive': commerceEvent.nonInteractive,
+      'customAttributes': commerceEvent.customAttributes,
+      'customFlags': commerceEvent.customFlags
     };
     ProductActionType? productActionType = commerceEvent.productActionType;
     PromotionActionType? promotionActionType = commerceEvent.promotionActionType;


### PR DESCRIPTION
# Summary

It looks like this got missed in the rebase, but we need to add customAttributes and customFlags to the CommerceEvent class to match the initial implementation