### PR TITLE
feat: Implement ScreenEvent and MPEvent classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the table below to see what features are currently supported. The Flutter mP
 | Custom Events | X | X | X |  |
 | Page Views | X | X | X |  |
 | Identity | X | X | X |  |
-| eCommerce |  |  |  | Coming Soon |
+| eCommerce | X | X | X |  |
 | Consent |  |  |  | Coming Soon |
 
 
@@ -259,27 +259,87 @@ MparticleFlutterSdk? mpInstance = await MparticleFlutterSdk.getInstance();
 
 ## Log Events
 
-To log events, import mParticle `EventTypes` to write proper event logging calls:
+To log events, import mParticle `EventTypes` and `MPEvent` to write proper event logging calls:
 
 ```dart
 import 'package:mparticle_flutter_sdk/events/event_type.dart';
+import 'package:mparticle_flutter_sdk/events/mp_event.dart';
 
-mpInstance?.logEvent(
-    eventName: 'Clicked Search Bar',
-    eventType: EventType.Search,
-    customAttributes: {'key1': 'value1'},
-    customFlags: {'flag1': 'flagValue1'});
+MPEvent event = MPEvent('Clicked Search Bar', EventType.Search)
+  ..customAttributes = { 'key1': 'value1' }
+  ..customFlags = { 'flag1': 'value1' };
+mpInstance?.logEvent(event);
 ```
 
 
-To log screen events:
+To log screen events, import mParticle `ScreenEvent`:
 
 ```dart
-mpInstance?.logScreenEvent(
-    eventName: 'Screen event logged',
-    customAttributes: {'key1': 'value1'},
-    customFlags: {'flag1': 'flagValue1'});
+import 'package:mparticle_flutter_sdk/events/screen_event.dart';
+
+ScreenEvent screenEvent = ScreenEvent('Screen event logged')
+  ..customAttributes = { 'key1': 'value1' }
+  ..customFlags = { 'flag1': 'value1' };
+mpInstance?.logScreenEvent(screenEvent);
 }
+```
+
+## Commerce Events
+
+To log product commerce events, import `CommerceEvent`, `Product` and `ProductActionType` (optionally `TransactionAttributes`)
+
+```dart
+import 'package:mparticle_flutter_sdk/events/commerce_event.dart';
+import 'package:mparticle_flutter_sdk/events/product.dart';
+import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
+
+final Product product1 = Product('Orange', '123abc', 5.0, 1);
+final Product product2 = Product('Apple', '456abc', 10.5, 2);
+final TransactionAttributes transactionAttributes =
+  TransactionAttributes('123456', 'affiliation', '12412342',
+      1.34, 43.232, 242.2323);
+CommerceEvent commerceEvent = CommerceEvent.withProduct(ProductActionType.Purchase, product1)
+    ..products.add(product2)
+    ..transactionAttributes = transactionAttributes
+    ..currency = 'US'
+    ..screenName = 'One Click Purchase';
+mpInstance?.logCommerceEvent(commerceEvent);
+```
+
+To log promotion commerce events, import `CommerceEvent`, `Promotion` and `PromotionActionType`:
+
+```dart
+import 'package:mparticle_flutter_sdk/events/commerce_event.dart';
+import 'package:mparticle_flutter_sdk/events/promotion.dart';
+import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
+
+final Promotion promotion1 = Promotion('12312', 'Jennifer Slater', 'BOGO Bonanza', 'top');
+final Promotion promotion2 = Promotion('15632', 'Gregor Roman', 'Eco Living', 'mid');
+
+CommerceEvent commerceEvent = CommerceEvent.withPromotion(PromotionActionType.View, promotion1)
+    ..promotions.add(promotion2)
+    ..currency = 'US'
+    ..screenName = 'OneClickPurchase';
+mpInstance?.logCommerceEvent(commerceEvent);
+```
+
+To log impression commerce events, import `CommerceEvent`, `Impression` and `Product`
+
+```dart
+import 'package:mparticle_flutter_sdk/events/commerce_event.dart';
+import 'package:mparticle_flutter_sdk/events/impression.dart';
+import 'package:mparticle_flutter_sdk/events/product.dart';
+
+final Product product1 = Product('Orange', '123abc', 2.4, 1);
+final Product product2 = Product('Apple', '456abc', 4.1, 2);
+final Impression impression1 = Impression('produce', [product1, product2]);
+final Impression impression2 = Impression('citrus', [product1]);
+CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
+  ..impressions.add(impression2)
+  ..currency = 'US'
+  ..screenName = 'One Click Purchase';
+mpInstance?.logCommerceEvent(commerceEvent);
 ```
 
 ## User

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,8 @@ import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
 import 'package:mparticle_flutter_sdk/events/promotion.dart';
 import 'package:mparticle_flutter_sdk/events/product.dart';
 import 'package:mparticle_flutter_sdk/events/impression.dart';
+import 'package:mparticle_flutter_sdk/events/screen_event.dart';
+import 'package:mparticle_flutter_sdk/events/mp_event.dart';
 import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_type.dart';
 import 'package:mparticle_flutter_sdk/kits/kits.dart';
@@ -111,17 +113,16 @@ class _MyAppState extends State<MyApp> {
               child: Text('EVENT LOGGING'),
             ),
             buildButton('Log Event', () {
-              mpInstance?.logEvent(
-                  eventName: 'Test event logged',
-                  eventType: EventType.Navigation,
-                  customAttributes: {'key1': 'value1'},
-                  customFlags: {'flag1': 'flagValue1'});
+              MPEvent event = MPEvent('Test event logged', EventType.Navigation)
+                ..customAttributes = {'key1': 'value1'}
+                ..customFlags = {'flag1': 'flagValue1'};
+              mpInstance?.logEvent(event);
             }),
             buildButton('Log Screen Event', () {
-              mpInstance?.logScreenEvent(
-                  eventName: 'Screen event logged',
-                  customAttributes: {'key1': 'value1'},
-                  customFlags: {'flag1': 'flagValue1'});
+              ScreenEvent screenEvent = ScreenEvent('Screen event logged')
+                ..customAttributes = {'key1': 'value1'}
+                ..customFlags = {'flag1': 'flagValue1'};
+              mpInstance?.logScreenEvent(screenEvent);
             }),
             buildButton('Log Commerce - Product', () {
               final Product product1 = Product('Orange', '123abc', 2.4, 1);
@@ -129,7 +130,7 @@ class _MyAppState extends State<MyApp> {
               final TransactionAttributes transactionAttributes =
                   TransactionAttributes('123456', 'affiliation', '12412342',
                       1.34, 43.232, 242.2323);
-              CommerceEvent commerceEvent = new CommerceEvent.withProduct(ProductActionType.Purchase, product1)
+              CommerceEvent commerceEvent = CommerceEvent.withProduct(ProductActionType.Purchase, product1)
                 ..products.add(product2)
                 ..transactionAttributes = transactionAttributes
                 ..currency = 'US'
@@ -154,7 +155,7 @@ class _MyAppState extends State<MyApp> {
               final Impression impression1 =
                   Impression('produce', [product1, product2]);
               final Impression impression2 = Impression('citrus', [product1]);
-              CommerceEvent commerceEvent = new CommerceEvent.withImpression(impression1)
+              CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
                   ..impressions.add(impression2)
                   ..currency = 'US'
                   ..screenName = 'One Click Purchase';

--- a/lib/events/mp_event.dart
+++ b/lib/events/mp_event.dart
@@ -1,0 +1,10 @@
+import 'event_type.dart';
+
+class MPEvent {
+  String eventName;
+  final EventType? eventType;
+  Map<String, String?>? customAttributes;
+  Map<String, dynamic>? customFlags;
+
+  MPEvent(this.eventName, [this.eventType]);
+}

--- a/lib/events/screen_event.dart
+++ b/lib/events/screen_event.dart
@@ -1,0 +1,7 @@
+class ScreenEvent {
+  String eventName;
+  Map<String, String?>? customAttributes;
+  Map<String, dynamic>? customFlags;
+
+  ScreenEvent(this.eventName);
+}

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -14,6 +14,8 @@ import 'package:mparticle_flutter_sdk/src/commerce/commerce_helpers.dart';
 import 'package:mparticle_flutter_sdk/src/identity/identity_helpers.dart';
 import 'package:mparticle_flutter_sdk/src/user.dart';
 
+import 'events/mp_event.dart';
+import 'events/screen_event.dart';
 import 'identity/alias_request.dart';
 import 'identity/identity_api_result.dart';
 import 'identity/identity_type.dart';
@@ -115,18 +117,13 @@ class MparticleFlutterSdk {
     });
   }
 
-  /// Logs a custom event with an [eventName], [eventType], [customAttributes], and [customFlags]
-  Future<void> logEvent({
-    required String eventName,
-    EventType? eventType,
-    Map<String, String?>? customAttributes,
-    Map<String, dynamic>? customFlags,
-  }) async {
+  /// Logs an MPEvent
+  Future<void> logEvent(MPEvent event) async {
     return await _channel.invokeMethod('logEvent', {
-      'eventName': eventName,
-      'eventType': EventType.values.indexOf(eventType as EventType),
-      'customAttributes': customAttributes,
-      'customFlags': customFlags
+      'eventName': event.eventName,
+      'eventType': EventType.values.indexOf(event.eventType as EventType),
+      'customAttributes': event.customAttributes,
+      'customFlags': event.customFlags
     });
   }
 
@@ -143,15 +140,11 @@ class MparticleFlutterSdk {
   }
 
   /// Logs a screen event (in web parlance, a 'page view') with an [eventName], [customAttributes], and [customFlags]
-  Future<void> logScreenEvent({
-    String eventName = '',
-    Map<String, String?>? customAttributes,
-    Map<String, dynamic>? customFlags,
-  }) async {
+  Future<void> logScreenEvent(ScreenEvent screenEvent) async {
     return await _channel.invokeMethod('logScreenEvent', {
-      'eventName': eventName,
-      'customAttributes': customAttributes,
-      'customFlags': customFlags
+      'eventName': screenEvent.eventName,
+      'customAttributes': screenEvent.customAttributes,
+      'customFlags': screenEvent.customFlags
     });
   }
 


### PR DESCRIPTION
# Summary

Implement `MPEvent` and `ScreenEvent`, replace usage in `logEvent()` and `logScreenEvent()`.

I do think there is a case that using "CusomtEvent" would make more sense, but in terms of consistency with the native SDKs and all the other plugin/wrapper SDKS, "MPEvent" is definitely the current norm.

I also did not try to do any sort of inheritance. Even though it's true that "ScreenEvent _is an_ MPEvent", we're in the plugin layer so we're not set up to accept `ScreenEvents` in `logEvent(MPEvent)`, and saving a few lines of code isn't worth the additional complexity in accounting for that
