### PR TITLE
fix: Properly pass ATT status from Dart Layer to native

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:mparticle_flutter_sdk/identity/alias_request.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_api_result.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_api_error_response.dart';
 import 'package:mparticle_flutter_sdk/identity/client_error_codes.dart';
+import 'package:mparticle_flutter_sdk/apple/authorization_status.dart';
 
 void main() {
   runApp(MyApp());
@@ -380,6 +381,10 @@ class _MyAppState extends State<MyApp> {
               user?.getLastSeen((time) {
                 print(time);
               });
+            }),
+            buildButton('set att status', () async {
+              mpInstance?.setATTStatus(
+                  attStatus: MPATTAuthorizationStatus.Authorized);
             }),
           ],
         ),

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -158,8 +158,8 @@ class MparticleFlutterSdk {
     required MPATTAuthorizationStatus attStatus,
     int? timestampInMillis,
   }) async {
-    return await _channel.invokeMethod('setAttStatus', {
-      'attStatus': attStatus,
+    return await _channel.invokeMethod('setATTStatus', {
+      'attStatus': MPATTAuthorizationStatus.values.indexOf(attStatus),
       'timestampInMillis': timestampInMillis,
     });
   }


### PR DESCRIPTION
# Summary
Exception occurs when attempting to setATTStatus. This is happening because the status is being sent as an enum from the app to dart, then from dart to ios. From dart to iOS this needs to be turned into a number and mapped on the iOS side to the right enum, similar to the event type enum:

TP: 72060

# Testing
<img width="1471" alt="Screen Shot 2021-09-15 at 1 53 05 PM" src="https://user-images.githubusercontent.com/33703490/133486150-16851679-16f6-4ec2-99c9-2d9044d76ffc.png">
