### PR TITLE
feat: Add tests to Dart API Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ final Impression impression2 = Impression('citrus', [product1]);
 CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
   ..impressions.add(impression2)
   ..currency = 'US'
-  ..screenName = 'ImpressionScren';
+  ..screenName = 'ImpressionScreen';
 mpInstance?.logCommerceEvent(commerceEvent);
 ```
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ ScreenEvent screenEvent = ScreenEvent('Screen event logged')
   ..customAttributes = { 'key1': 'value1' }
   ..customFlags = { 'flag1': 'value1' };
 mpInstance?.logScreenEvent(screenEvent);
-}
 ```
 
 ## Commerce Events
@@ -320,7 +319,7 @@ final Promotion promotion2 = Promotion('15632', 'Gregor Roman', 'Eco Living', 'm
 CommerceEvent commerceEvent = CommerceEvent.withPromotion(PromotionActionType.View, promotion1)
     ..promotions.add(promotion2)
     ..currency = 'US'
-    ..screenName = 'OneClickPurchase';
+    ..screenName = 'PromotionScreen';
 mpInstance?.logCommerceEvent(commerceEvent);
 ```
 
@@ -338,7 +337,7 @@ final Impression impression2 = Impression('citrus', [product1]);
 CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
   ..impressions.add(impression2)
   ..currency = 'US'
-  ..screenName = 'One Click Purchase';
+  ..screenName = 'ImpressionScren';
 mpInstance?.logCommerceEvent(commerceEvent);
 ```
 
@@ -352,64 +351,68 @@ var user = await mpInstance?.getCurrentUser();
 User Attributes:
 
 ```dart
-user.setUserAttribute('age', '45');
+user?.setUserAttribute('age', '45');
 ```
 
 ```dart
-user.setUserAttributeArray('Test key', ['Test value 1', 'Test value 2']);
+user?.setUserAttributeArray('Test key', ['Test value 1', 'Test value 2']);
 ```
 
 ```dart
-user.setUserTag('tag1');
+user?.setUserTag('tag1');
 ```
 
 ```dart
-user.getUserAttributes('tag1');
+user?.getUserAttributes();
 ```
 
 
 ```dart
-user.removeUserAttribute('age')
+user?.removeUserAttribute('age')
 ```
 
 ```dart
-user.getUserIdentities().then((identities) {
+user?.getUserIdentities().then((identities) {
     print(identities); // Map<IdentityType, String>
 });
 ```
 
-## IdentityRequest
+
+## IDSync
+IDSync is mParticle’s identity framework, enabling our customers to create a unified view of the customer. To read more about IDSync, see [here](https://docs.mparticle.com/guides/idsync/introduction).
+
+All IDSync calls require an `Identity Request`.
+
+### IdentityRequest
 
 ```dart
+import 'package:mparticle_flutter_sdk/identity/identity_type.dart';
+
 var identityRequest = MparticleFlutterSdk.identityRequest;
 identityRequest
     .setIdentity(IdentityType.CustomerId, 'customerid5')
     .setIdentity(IdentityType.Email, 'email5@gmail.com');
 ```
 
-## Identity
-
-```dart
-mpInstance.getCurrentUser((currentUser) => {
-    print(currentUser?.getMPID());
-});
-```
+After an IdentityRequest is passed to one of the following IDSync methods -  `identify`, `login`, `logout`, or `modify`.
 
 Import the `SuccessResponse` and `FailureResponse` classes to write proper callbacks for Identity methods.  For brevity, we included an example of full error handling in only the `identify` example below, but this error handling can be used for any of the Identity calls.
 
+### Identify
+The following is a full Identify example with error and success handling.
 ```dart
-import 'package:mparticle_flutter_sdk/identity/success_response.dart';
-import 'package:mparticle_flutter_sdk/identity/failure_response.dart';
+import 'package:mparticle_flutter_sdk/identity/identity_api_result.dart';
+import 'package:mparticle_flutter_sdk/identity/identity_api_error_response.dart';
 
 var request = MparticleFlutterSdk.identityRequest();
 
 mpInstance?.identity
     .identify(identityRequest: identityRequest)
     .then(
-        (SuccessResponse successResponse) =>
+        (IdentityApiResult successResponse) =>
             print("Success Response: $successResponse"),
         onError: (error) {
-            var failureResponse = error as FailureResponse;
+            var failureResponse = error as IdentityAPIErrorResponse;
             print("Failure Response: $failureResponse");
 
             // It is possible for either a client error or a server error to occur during identity calls.
@@ -455,6 +458,7 @@ mpInstance?.identity
     );
 ```
 
+### Login
 ```dart
 var identityRequest = MparticleFlutterSdk.identityRequest;
 identityRequest
@@ -464,15 +468,16 @@ identityRequest
 mpInstance?.identity
     .login(identityRequest: identityRequest)
     .then(
-        (SuccessResponse successResponse) =>
+        (IdentityApiResult successResponse) =>
             print("Success Response: $successResponse"),
         onError: (error) {
-            var failureResponse = error as FailureResponse;
+            var failureResponse = error as IdentityAPIErrorResponse;
             print("Failure Response: $failureResponse");
         }
     );
 ```
 
+### Modify
 ```dart
 var identityRequest = MparticleFlutterSdk.identityRequest;
 identityRequest
@@ -482,15 +487,16 @@ identityRequest
 mpInstance?.identity
     .modify(identityRequest: identityRequest)
     .then(
-        (SuccessResponse successResponse) =>
+        (IdentityApiResult successResponse) =>
             print("Success Response: $successResponse"),
         onError: (error) {
-            var failureResponse = error as FailureResponse;
+            var failureResponse = error as IdentityAPIErrorResponse;
             print("Failure Response: $failureResponse");
         }
     );
 ```
 
+### Logout
 ```dart
 var identityRequest = MparticleFlutterSdk.identityRequest;
 // depending on your identity strategy, you may have identities added to your identityRequestk
@@ -498,16 +504,30 @@ var identityRequest = MparticleFlutterSdk.identityRequest;
 mpInstance?.identity
     .logout(identityRequest: identityRequest)
     .then(
-        (SuccessResponse successResponse) =>
+        (IdentityApiResult successResponse) =>
             print("Success Response: $successResponse"),
         onError: (error) {
-            var failureResponse = error as FailureResponse;
+            var failureResponse = error as IdentityAPIErrorResponse;
             print("Failure Response: $failureResponse");
         }
     );
 ```
 
-
+### Aliasing Users
+This is a feature to transition data from "anonymous" users to "known" users.  To learn more about user aliasing, see [here](https://docs.mparticle.com/guides/idsync/aliasing/).
+```dart
+mpInstance?.identity.login(identityRequest: identityRequest).then(
+    (IdentityApiResult successResponse) {
+        String? previousMPID = successResponse.previousUser?.getMPID();
+        if (previousMPID != null) {
+            var userAliasRequest = AliasRequest(
+                previousMPID, successResponse.user.getMPID()
+            );
+            mpInstance?.identity.aliasUsers(aliasRequest: userAliasRequest);
+        }
+    }
+);
+```
 
 # Native-only Methods
 A few methods are currently supported only on iOS/Android SDKs:
@@ -515,14 +535,16 @@ A few methods are currently supported only on iOS/Android SDKs:
 * Get the SDK's opt out status -
 
     ```dart
-    var isOptedOut = await mpInstance.getOptOut;
-    MParticle.setOptOut(!isOptedOut);
+    var isOptedOut = await mpInstance?.getOptOut;
+    mpInstance?.setOptOut(optOutBoolean: !isOptedOut!);
     ```
 
 * Check if a kit is active
 
     ```dart
-    mpInstance.isKitActive(kitId).then((isActive) {
+    import 'package:mparticle_flutter_sdk/kits/kits.dart';
+
+    mpInstance?.isKitActive(kit: Kits['Braze']!).then((isActive) {
         print(isActive);
     });
     ```
@@ -534,13 +556,25 @@ A few methods are currently supported only on iOS/Android SDKs:
     ### Android
 
     ```dart
-    mpInstance.logPushRegistration(pushToken, senderId);
+    mpInstance?.logPushRegistration(pushToken: 'pushToken123', senderId: 'senderId123');
     ```
 
     ### iOS
 
     ```dart
-    mpInstance.logPushRegistration(pushToken, null);
+    mpInstance?.logPushRegistration(pushToken: 'pushToken123', senderId: null);
+    ```
+
+* Set App Tracking Transparency (ATT) Status
+
+    For iOS, you can set a user's ATT status as follows:
+    import 'package:mparticle_flutter_sdk/apple/authorization_status.dart';
+
+    ```dart
+    
+    mpInstance?.setATTStatus(
+          attStatus: MPATTAuthorizationStatus.Authorized,
+          timestampInMillis: DateTime.now().millisecondsSinceEpoch);
     ```
 
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -161,7 +161,7 @@ class _MyAppState extends State<MyApp> {
                   PromotionActionType.View, promotion1)
                 ..promotions.add(promotion2)
                 ..currency = 'US'
-                ..screenName = 'OneClickPurchase'
+                ..screenName = 'PromotionScreen'
                 ..customAttributes = {"foo": "bar", "fuzz": "baz"}
                 ..customFlags = {
                   "flag1": "val1",
@@ -179,7 +179,7 @@ class _MyAppState extends State<MyApp> {
                   CommerceEvent.withImpression(impression1)
                     ..impressions.add(impression2)
                     ..currency = 'US'
-                    ..screenName = 'One Click Purchase'
+                    ..screenName = 'ImpressionScreen'
                     ..customAttributes = {"foo": "bar", "fuzz": "baz"}
                     ..customFlags = {
                       "flag1": "val1",

--- a/test/mparticle_flutter_sdk_test.dart
+++ b/test/mparticle_flutter_sdk_test.dart
@@ -1,18 +1,273 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mparticle_flutter_sdk/mparticle_flutter_sdk.dart';
+import 'package:mparticle_flutter_sdk/events/event_type.dart';
+import 'package:mparticle_flutter_sdk/events/mp_event.dart';
+import 'package:mparticle_flutter_sdk/events/commerce_event.dart';
+import 'package:mparticle_flutter_sdk/events/product.dart';
+import 'package:mparticle_flutter_sdk/events/product_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/transaction_attributes.dart';
+import 'package:mparticle_flutter_sdk/events/promotion.dart';
+import 'package:mparticle_flutter_sdk/events/promotion_action_type.dart';
+import 'package:mparticle_flutter_sdk/events/impression.dart';
+import 'package:mparticle_flutter_sdk/events/screen_event.dart';
+import 'package:mparticle_flutter_sdk/identity/alias_request.dart';
+import 'package:mparticle_flutter_sdk/apple/authorization_status.dart';
 
 void main() {
   const MethodChannel channel = MethodChannel('mparticle_flutter_sdk');
-
+  MethodCall? methodCall;
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
+  MparticleFlutterSdk mp = MparticleFlutterSdk();
+
+  setUp(() async {
+    channel.setMockMethodCallHandler((MethodCall call) async {
+      methodCall = call;
     });
   });
 
   tearDown(() {
     channel.setMockMethodCallHandler(null);
+    methodCall = null;
+  });
+
+  group('mParticle Dart API Layer', () {
+    test('logEvent', () async {
+      MPEvent event = MPEvent('Clicked Search Bar', EventType.Search)
+        ..customAttributes = {'key1': 'value1'}
+        ..customFlags = {'flag1': 'value1'};
+
+      await mp.logEvent(event);
+      expect(
+        methodCall,
+        isMethodCall(
+          'logEvent',
+          arguments: {
+            'eventName': 'Clicked Search Bar',
+            'eventType': 3,
+            'customAttributes': {'key1': 'value1'},
+            'customFlags': {'flag1': 'value1'},
+            'shouldUploadEvent': null
+          },
+        ),
+      );
+    });
+
+    test('log product action commerce event', () async {
+      final Product product1 = Product('Orange', '123abc', 5.0, 1);
+      final Product product2 = Product('Apple', '456abc', 10.5, 2);
+      final TransactionAttributes transactionAttributes = TransactionAttributes(
+          '123456', 'affiliation', '12412342', 1.34, 43.232, 242.2323);
+      CommerceEvent commerceEvent =
+          CommerceEvent.withProduct(ProductActionType.Purchase, product1)
+            ..products.add(product2)
+            ..transactionAttributes = transactionAttributes
+            ..currency = 'US'
+            ..screenName = 'One Click Purchase';
+      mp.logCommerceEvent(commerceEvent);
+      expect(
+        methodCall,
+        isMethodCall(
+          'logCommerceEvent',
+          arguments: {
+            'commerceEvent': {
+              'products': [product1.toJson(), product2.toJson()],
+              'promotions': [],
+              'impressions': [],
+              'transactionAttributes': transactionAttributes.toJson(),
+              'checkoutOptions': null,
+              'currency': 'US',
+              'productListName': null,
+              'productListSource': null,
+              'screenName': 'One Click Purchase',
+              'checkoutStep': null,
+              'nonInteractive': null,
+              'shouldUploadEvent': null,
+              'customAttributes': null,
+              'customFlags': null,
+              'productActionType': 8,
+              'jsProductActionType': 6,
+              'androidProductActionType': 'purchase',
+            }
+          },
+        ),
+      );
+    });
+
+    test('log promotion commerce event', () async {
+      final Promotion promotion1 =
+          Promotion('12312', 'Jennifer Slater', 'BOGO Bonanza', 'top');
+      final Promotion promotion2 =
+          Promotion('15632', 'Gregor Roman', 'Eco Living', 'mid');
+
+      CommerceEvent commerceEvent =
+          CommerceEvent.withPromotion(PromotionActionType.View, promotion1)
+            ..promotions.add(promotion2)
+            ..currency = 'US'
+            ..screenName = 'Promotion Screen Name';
+      mp.logCommerceEvent(commerceEvent);
+      expect(
+        methodCall,
+        isMethodCall(
+          'logCommerceEvent',
+          arguments: {
+            'commerceEvent': {
+              'products': [],
+              'promotions': [
+                {
+                  'promotionId': '12312',
+                  'creative': 'Jennifer Slater',
+                  'name': 'BOGO Bonanza',
+                  'position': 'top'
+                },
+                {
+                  'promotionId': '15632',
+                  'creative': 'Gregor Roman',
+                  'name': 'Eco Living',
+                  'position': 'mid'
+                }
+              ],
+              'impressions': [],
+              'transactionAttributes': null,
+              'checkoutOptions': null,
+              'currency': 'US',
+              'productListName': null,
+              'productListSource': null,
+              'screenName': 'Promotion Screen Name',
+              'checkoutStep': null,
+              'nonInteractive': null,
+              'shouldUploadEvent': null,
+              'customAttributes': null,
+              'customFlags': null,
+              'promotionActionType': 1,
+              'androidPromotionActionType': 'view',
+              'jsPromotionActionType': 1
+            }
+          },
+        ),
+      );
+    });
+
+    test('log impression commerce event', () async {
+      final Product product1 = Product('Orange', '123abc', 2.4, 1);
+      final Impression impression1 = Impression('produce', [product1]);
+      final Impression impression2 = Impression('citrus', [product1]);
+      CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
+        ..impressions.add(impression2)
+        ..currency = 'US'
+        ..screenName = 'One Click Purchase';
+      mp.logCommerceEvent(commerceEvent);
+      expect(
+        methodCall,
+        isMethodCall(
+          'logCommerceEvent',
+          arguments: {
+            'commerceEvent': {
+              'products': [],
+              'promotions': [],
+              'impressions': [impression1.toJson(), impression2.toJson()],
+              'transactionAttributes': null,
+              'checkoutOptions': null,
+              'currency': 'US',
+              'productListName': null,
+              'productListSource': null,
+              'screenName': 'One Click Purchase',
+              'checkoutStep': null,
+              'nonInteractive': null,
+              'shouldUploadEvent': null,
+              'customAttributes': null,
+              'customFlags': null,
+            }
+          },
+        ),
+      );
+    });
+
+    test('log error', () async {
+      mp.logError(eventName: 'Error', customAttributes: {'key1': 'value1'});
+
+      expect(
+        methodCall,
+        isMethodCall('logError', arguments: {
+          'eventName': 'Error',
+          'customAttributes': {'key1': 'value1'},
+        }),
+      );
+    });
+
+    test('log push registration', () async {
+      mp.logPushRegistration(
+          pushToken: 'pushToken123', senderId: 'senderId123');
+
+      expect(
+        methodCall,
+        isMethodCall('logPushRegistration', arguments: {
+          'pushToken': 'pushToken123',
+          'senderId': 'senderId123',
+        }),
+      );
+    });
+
+    test('log screen event', () async {
+      ScreenEvent screenEvent = ScreenEvent('Screen event logged')
+        ..customAttributes = {'key1': 'value1'}
+        ..customFlags = {'flag1': 'value1'};
+      mp.logScreenEvent(screenEvent);
+
+      expect(
+        methodCall,
+        isMethodCall('logScreenEvent', arguments: {
+          'eventName': 'Screen event logged',
+          'customAttributes': {'key1': 'value1'},
+          'customFlags': {'flag1': 'value1'},
+        }),
+      );
+    });
+
+    test('set att status', () async {
+      mp.setATTStatus(
+          attStatus: MPATTAuthorizationStatus.Authorized,
+          timestampInMillis: 1000);
+      expect(
+        methodCall,
+        isMethodCall('setATTStatus',
+            arguments: {'attStatus': 3, 'timestampInMillis': 1000}),
+      );
+    });
+
+    test('set opt out', () async {
+      mp.setOptOut(optOutBoolean: true);
+      expect(
+        methodCall,
+        isMethodCall('setOptOut', arguments: {'optOutBoolean': true}),
+      );
+    });
+
+    test('upload', () async {
+      mp.upload();
+      expect(
+        methodCall,
+        isMethodCall('upload', arguments: null),
+      );
+    });
+
+    test('alias users', () async {
+      var userAliasRequest = AliasRequest('sourceMPID', 'destinationMPID');
+      userAliasRequest.setStartTime(123);
+      userAliasRequest.setEndTime(456);
+      mp.identity.aliasUsers(aliasRequest: userAliasRequest);
+      expect(
+        methodCall,
+        isMethodCall('aliasUsers', arguments: {
+          "aliasRequest": {
+            'sourceMpid': 'sourceMPID',
+            'destinationMpid': 'destinationMPID',
+            'startTime': 123,
+            'endTime': 456,
+          }
+        }),
+      );
+    });
   });
 }


### PR DESCRIPTION
# Summary

This is a first pass at adding the Dart Layer API tests.  Currently this only tests "fire and forget" methods, where we post data to our servers.  In the future I will add more unit tests for specific classes, but this will get us going for now.

Additionally I noticed that some parts of the readme were wrong:
* a few places where `mpInstance?` was missing
* updated filenames
* updated class names