### PR TITLE
feat: Migrate to named parameters, add additional documentation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,42 +115,54 @@ class _MyAppState extends State<MyApp> {
               child: Text('EVENT LOGGING'),
             ),
             buildButton('Log Event', () {
-              MPEvent event = MPEvent('Test event logged', EventType.Navigation)
-                ..customAttributes = {'key1': 'value1'}
-                ..customFlags = {'flag1': 'flagValue1'};
+              MPEvent event = MPEvent(
+                  eventName: 'Test event logged',
+                  eventType: EventType.Navigation,
+                  customAttributes: {'key1': 'value1'},
+                  customFlags: {'flag1': 'flagValue1'});
               mpInstance?.logEvent(event);
             }),
             buildButton('Log Event - No Upload', () {
-              MPEvent event = MPEvent('Test event logged', EventType.Navigation)
-                ..customAttributes = {'key1': 'value1'}
-                ..customFlags = {'flag1': 'flagValue1'}
+              MPEvent event = MPEvent(
+                  eventName: 'Test event logged',
+                  eventType: EventType.Navigation,
+                  customAttributes: {'key1': 'value1'},
+                  customFlags: {'flag1': 'flagValue1'})
                 ..shouldUploadEvent = false;
               mpInstance?.logEvent(event);
             }),
             buildButton('Log Screen Event', () {
-              ScreenEvent screenEvent = ScreenEvent('Screen event logged')
-                ..customAttributes = {'key1': 'value1'}
-                ..customFlags = {'flag1': 'flagValue1'};
+              ScreenEvent screenEvent =
+                  ScreenEvent(eventName: 'Screen event logged')
+                    ..customAttributes = {'key1': 'value1'}
+                    ..customFlags = {'flag1': 'flagValue1'};
               mpInstance?.logScreenEvent(screenEvent);
             }),
             buildButton('Log Commerce - Product', () {
-              final Product product1 = Product('Orange', '123abc', 2.4, 1);
+              final Product product1 = Product(
+                  name: 'Orange', sku: '123abc', price: 2.4, quantity: 1);
               final Product product2 = Product(
-                  'Apple',
-                  '456abc',
-                  4.1,
-                  2,
-                  'variant',
-                  'category',
-                  'brand',
-                  1,
-                  'couponCode',
-                  {'key1': 'value1'});
+                  name: 'Apple',
+                  sku: '456abc',
+                  price: 4.1,
+                  quantity: 2,
+                  variant: 'variant',
+                  category: 'category',
+                  brand: 'brand',
+                  position: 1,
+                  couponCode: 'couponCode',
+                  attributes: {'key1': 'value1'});
               final TransactionAttributes transactionAttributes =
-                  TransactionAttributes('123456', 'affiliation', '12412342',
-                      1.34, 43.232, 242.2323);
+                  TransactionAttributes(
+                      transactionId: '123456',
+                      affiliation: 'affiliation',
+                      couponCode: '12412342',
+                      shipping: 1.34,
+                      tax: 43.23,
+                      revenue: 242.23);
               CommerceEvent commerceEvent = CommerceEvent.withProduct(
-                  ProductActionType.Purchase, product1)
+                  productActionType: ProductActionType.Purchase,
+                  product: product1)
                 ..products.add(product2)
                 ..transactionAttributes = transactionAttributes
                 ..currency = 'US'
@@ -163,13 +175,20 @@ class _MyAppState extends State<MyApp> {
               mpInstance?.logCommerceEvent(commerceEvent);
             }),
             buildButton('Log Commerce - Promotion', () {
-              final Promotion promotion1 =
-                  Promotion('12312', 'Jennifer Slater', 'BOGO Bonanza', 'top');
-              final Promotion promotion2 =
-                  Promotion('15632', 'Gregor Roman', 'Eco Living', 'mid');
+              final Promotion promotion1 = Promotion(
+                  promotionId: '12312',
+                  creative: 'Jennifer Slater',
+                  name: 'BOGO Bonanza',
+                  position: 'top');
+              final Promotion promotion2 = Promotion(
+                  promotionId: '15632',
+                  creative: 'Gregor Roman',
+                  name: 'Eco Living',
+                  position: 'mid');
 
               CommerceEvent commerceEvent = CommerceEvent.withPromotion(
-                  PromotionActionType.View, promotion1)
+                  promotionActionType: PromotionActionType.View,
+                  promotion: promotion1)
                 ..promotions.add(promotion2)
                 ..currency = 'US'
                 ..screenName = 'PromotionScreen'
@@ -181,23 +200,26 @@ class _MyAppState extends State<MyApp> {
               mpInstance?.logCommerceEvent(commerceEvent);
             }),
             buildButton('Log Commerce - Impression', () {
-              final Product product1 = Product('Orange', '123abc', 2.4, 1);
+              final Product product1 = Product(
+                  name: 'Orange', sku: '123abc', price: 2.4, quantity: 1);
               final Product product2 = Product(
-                  'Apple',
-                  '456abc',
-                  4.1,
-                  2,
-                  'variant',
-                  'category',
-                  'brand',
-                  1,
-                  'couponCode',
-                  {'key1': 'value1'});
-              final Impression impression1 =
-                  Impression('produce', [product1, product2]);
-              final Impression impression2 = Impression('citrus', [product1]);
+                  name: 'Apple',
+                  sku: '456abc',
+                  price: 4.1,
+                  quantity: 2,
+                  variant: 'variant',
+                  category: 'category',
+                  brand: 'brand',
+                  position: 1,
+                  couponCode: 'couponCode',
+                  attributes: {'key1': 'value1'});
+              final Impression impression1 = Impression(
+                  impressionListName: 'produce',
+                  products: [product1, product2]);
+              final Impression impression2 = Impression(
+                  impressionListName: 'citrus', products: [product1]);
               CommerceEvent commerceEvent =
-                  CommerceEvent.withImpression(impression1)
+                  CommerceEvent.withImpression(impression: impression1)
                     ..impressions.add(impression2)
                     ..currency = 'US'
                     ..screenName = 'ImpressionScreen'
@@ -209,13 +231,21 @@ class _MyAppState extends State<MyApp> {
               mpInstance?.logCommerceEvent(commerceEvent);
             }),
             buildButton('Log Commerce - No Upload', () {
-              final Product product1 = Product('Orange', '123abc', 2.4, 1);
-              final Product product2 = Product('Apple', '456abc', 4.1, 2);
+              final Product product1 = Product(
+                  name: 'Orange', sku: '123abc', price: 2.4, quantity: 1);
+              final Product product2 = Product(
+                  name: 'Apple', sku: '456abc', price: 4.1, quantity: 2);
               final TransactionAttributes transactionAttributes =
-                  TransactionAttributes('123456', 'affiliation', '12412342',
-                      1.34, 43.232, 242.2323);
+                  TransactionAttributes(
+                      transactionId: '123456',
+                      affiliation: 'affiliation',
+                      couponCode: '12412342',
+                      shipping: 1.34,
+                      tax: 43.23,
+                      revenue: 242.23);
               CommerceEvent commerceEvent = CommerceEvent.withProduct(
-                  ProductActionType.Purchase, product1)
+                  productActionType: ProductActionType.Purchase,
+                  product: product1)
                 ..products.add(product2)
                 ..transactionAttributes = transactionAttributes
                 ..currency = 'US'
@@ -245,10 +275,10 @@ class _MyAppState extends State<MyApp> {
               });
             }),
             buildButton('Set opt out', () {
-              mpInstance?.setOptOut(optOutBoolean: true);
+              mpInstance?.setOptOut(true);
             }),
             buildButton('Set Opt In', () {
-              mpInstance?.setOptOut(optOutBoolean: false);
+              mpInstance?.setOptOut(false);
             }),
             buildButton('Get opt out', () async {
               print(await mpInstance?.getOptOut);
@@ -262,32 +292,42 @@ class _MyAppState extends State<MyApp> {
             buildButton('Identify', () {
               var identityRequest = MparticleFlutterSdk.identityRequest;
               identityRequest
-                  .setIdentity(IdentityType.CustomerId, 'customerid')
-                  .setIdentity(IdentityType.Email, 'email@gmail.com');
+                  .setIdentity(
+                      identityType: IdentityType.CustomerId,
+                      value: 'customerid')
+                  .setIdentity(
+                      identityType: IdentityType.Email,
+                      value: 'email@gmail.com');
 
-              mpInstance?.identity
-                  .identify(identityRequest: identityRequest)
-                  .then(identityCallbackSuccess,
-                      onError: identityCallbackFailure);
+              mpInstance?.identity.identify(identityRequest).then(
+                  identityCallbackSuccess,
+                  onError: identityCallbackFailure);
             }),
             buildButton('Login', () {
               var identityRequest = MparticleFlutterSdk.identityRequest;
               identityRequest
-                  .setIdentity(IdentityType.CustomerId, 'customerid2')
-                  .setIdentity(IdentityType.Email, 'email2@gmail.com');
-              mpInstance?.identity.login(identityRequest: identityRequest).then(
+                  .setIdentity(
+                      identityType: IdentityType.CustomerId,
+                      value: 'customerid2')
+                  .setIdentity(
+                      identityType: IdentityType.Email,
+                      value: 'email2@gmail.com');
+              mpInstance?.identity.login(identityRequest).then(
                   identityCallbackSuccess,
                   onError: identityCallbackFailure);
             }),
             buildButton('Modify', () {
               var identityRequest = MparticleFlutterSdk.identityRequest;
               identityRequest
-                  .setIdentity(IdentityType.CustomerId, 'customerid3')
-                  .setIdentity(IdentityType.Email, 'email3@gmail.com');
-              mpInstance?.identity
-                  .modify(identityRequest: identityRequest)
-                  .then(identityCallbackSuccess,
-                      onError: identityCallbackFailure);
+                  .setIdentity(
+                      identityType: IdentityType.CustomerId,
+                      value: 'customerid3')
+                  .setIdentity(
+                      identityType: IdentityType.Email,
+                      value: 'email3@gmail.com');
+              mpInstance?.identity.modify(identityRequest).then(
+                  identityCallbackSuccess,
+                  onError: identityCallbackFailure);
             }),
             buildButton('Logout', () {
               var identityRequest = MparticleFlutterSdk.identityRequest;
@@ -296,37 +336,44 @@ class _MyAppState extends State<MyApp> {
               // To remove this error, comment the next 3 lines out where identities
               // are set on the identityRequest.
               identityRequest
-                  .setIdentity(IdentityType.CustomerId, 'customerid4')
-                  .setIdentity(IdentityType.Email, 'email4@gmail.com');
+                  .setIdentity(
+                      identityType: IdentityType.CustomerId,
+                      value: 'customerid4')
+                  .setIdentity(
+                      identityType: IdentityType.Email,
+                      value: 'email4@gmail.com');
 
-              mpInstance?.identity
-                  .logout(identityRequest: identityRequest)
-                  .then(identityCallbackSuccess,
-                      onError: identityCallbackFailure);
+              mpInstance?.identity.logout(identityRequest).then(
+                  identityCallbackSuccess,
+                  onError: identityCallbackFailure);
             }),
             buildButton('Alias Users with MPIDs and Times', () {
               var startTime = DateTime.now().millisecondsSinceEpoch - 60000;
               var endTime = DateTime.now().millisecondsSinceEpoch;
 
-              var userAliasRequest =
-                  AliasRequest('sourceMPID', 'destinationMPID');
+              var userAliasRequest = AliasRequest(
+                  sourceMpid: 'sourceMPID', destinationMpid: 'destinationMPID');
               userAliasRequest.setStartTime(startTime);
               userAliasRequest.setEndTime(endTime);
-              mpInstance?.identity.aliasUsers(aliasRequest: userAliasRequest);
+              mpInstance?.identity.aliasUsers(userAliasRequest);
             }),
             buildButton('Login then Alias Users with just MPIDs', () {
               var identityRequest = MparticleFlutterSdk.identityRequest;
               identityRequest
-                  .setIdentity(IdentityType.CustomerId, 'customerid5')
-                  .setIdentity(IdentityType.Email, 'email5@gmail.com');
-              mpInstance?.identity.login(identityRequest: identityRequest).then(
+                  .setIdentity(
+                      identityType: IdentityType.CustomerId,
+                      value: 'customerid5')
+                  .setIdentity(
+                      identityType: IdentityType.Email,
+                      value: 'email5@gmail.com');
+              mpInstance?.identity.login(identityRequest).then(
                   (IdentityApiResult successResponse) {
                 String? previousMPID = successResponse.previousUser?.getMPID();
                 if (previousMPID != null) {
                   var userAliasRequest = AliasRequest(
-                      previousMPID, successResponse.user.getMPID());
-                  mpInstance?.identity
-                      .aliasUsers(aliasRequest: userAliasRequest);
+                      sourceMpid: previousMPID,
+                      destinationMpid: successResponse.user.getMPID());
+                  mpInstance?.identity.aliasUsers(userAliasRequest);
                 }
               }, onError: (error) {
                 var failureResponse = error as IdentityAPIErrorResponse;
@@ -342,15 +389,16 @@ class _MyAppState extends State<MyApp> {
             }),
             buildButton('setUserAttribute', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.setUserAttribute('points', '1');
+              user?.setUserAttribute(key: 'points', value: '1');
             }),
             buildButton('Set User Tag', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.setUserTag('tag1');
+              user?.setUserTag(tag: 'tag1');
             }),
             buildButton('Set User Attribute Array', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.setUserAttributeArray('arrayOfStrings', ['a', 'b', 'c']);
+              user?.setUserAttributeArray(
+                  key: 'arrayOfStrings', value: ['a', 'b', 'c']);
             }),
             buildButton('Get User Attributes', () async {
               var user = await mpInstance?.getCurrentUser();
@@ -385,7 +433,7 @@ class _MyAppState extends State<MyApp> {
             }),
             buildButton('incrementUserAttribute by 1', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.incrementUserAttribute('points', 1);
+              user?.incrementUserAttribute(key: 'points', value: 1);
             }),
             buildButton('logPushNotification', () async {
               mpInstance?.logPushRegistration(
@@ -393,15 +441,17 @@ class _MyAppState extends State<MyApp> {
             }),
             buildButton('user - getFirstSeen time', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.getFirstSeen((time) {
+              int? time = await user?.getFirstSeen();
+              if (time != null) {
                 print(time);
-              });
+              }
             }),
             buildButton('user - getLastSeen time', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.getLastSeen((time) {
+              int? time = await user?.getLastSeen();
+              if (time != null) {
                 print(time);
-              });
+              }
             }),
             buildButton('user - get GDPR Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
@@ -426,22 +476,22 @@ class _MyAppState extends State<MyApp> {
             }),
             buildButton('user - add denied GDPR Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
-              var gdprConsent = (Consent(false))
+              var gdprConsent = (Consent(consented: false))
                 ..document = 'document test'
                 ..hardwareId = 'hardwareID'
                 ..location = 'loction test'
                 ..timestamp = DateTime.now().millisecondsSinceEpoch;
-              print('yoooo');
-              user?.addGDPRConsentState(gdprConsent, 'test');
+              user?.addGDPRConsentState(consent: gdprConsent, purpose: 'test');
             }),
             buildButton('user - add 2nd approved GDPR Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
-              var gdprConsent = Consent(true);
-              user?.addGDPRConsentState(gdprConsent, 'test 2');
+              var gdprConsent = Consent(consented: true);
+              user?.addGDPRConsentState(
+                  consent: gdprConsent, purpose: 'test 2');
             }),
             buildButton('user - remove GDPR Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
-              user?.removeGDPRConsentState('test');
+              user?.removeGDPRConsentState(purpose: 'test');
             }),
             buildButton('user - get CCPA Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
@@ -466,17 +516,17 @@ class _MyAppState extends State<MyApp> {
             }),
             buildButton('user - add denied CCPA Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
-              var ccpaConsent = (Consent(false))
+              var ccpaConsent = (Consent(consented: false))
                 ..document = 'document test'
                 ..hardwareId = 'hardwareID'
                 ..location = 'loction test'
                 ..timestamp = DateTime.now().millisecondsSinceEpoch;
-              user?.addCCPAConsentState(ccpaConsent);
+              user?.addCCPAConsentState(consent: ccpaConsent);
             }),
             buildButton('user - add approved CCPA Consent State', () async {
               var user = await mpInstance?.getCurrentUser();
-              var ccpaConsent = Consent(true);
-              user?.addCCPAConsentState(ccpaConsent);
+              var ccpaConsent = Consent(consented: true);
+              user?.addCCPAConsentState(consent: ccpaConsent);
             }),
             buildButton('user - remove CCPA Consent State', () async {
               var user = await mpInstance?.getCurrentUser();

--- a/lib/consent/consent.dart
+++ b/lib/consent/consent.dart
@@ -1,10 +1,24 @@
 /// This class represents an Consent Object to be logged using the mParticle SDK
 class Consent {
+  /// Whether the user consented to data collection
   bool consented;
+
+  /// The data collection document to which the user consented or did not consent
   String? document;
+
+  /// Timestamp when the user was prompted for consent
   int? timestamp;
+
+  /// Where the consent prompt took place. This can be a physical or digital location (e.g. URL)
   String? location;
+
+  /// The device ID associated with this consent record
   String? hardwareId;
 
-  Consent(this.consented);
+  Consent(
+      {required this.consented,
+      this.document,
+      this.timestamp,
+      this.location,
+      this.hardwareId});
 }

--- a/lib/events/commerce_event.dart
+++ b/lib/events/commerce_event.dart
@@ -8,41 +8,74 @@ import 'impression.dart';
 
 /// A commerce event
 ///
-/// A commerce event can either contain Products, Promotions, or Impressions
+/// A commerce event can either contain Products, Promotions, or Impressions.
 class CommerceEvent {
-  CommerceEvent.withProduct(this.productActionType, Product product)
+  /// Initializes an instance of a Commerce Event with an action and a product.
+  CommerceEvent.withProduct(
+      {required this.productActionType, required Product product})
       : promotionActionType = null {
     products.add(product);
   }
 
-  CommerceEvent.withPromotion(this.promotionActionType, Promotion promotion)
+  /// Initializes an instance of MPCommerceEvent with a promotion container
+  CommerceEvent.withPromotion(
+      {required this.promotionActionType, required Promotion promotion})
       : productActionType = null {
     promotions.add(promotion);
   }
 
-  CommerceEvent.withImpression(Impression impression)
+  /// Initializes an instance of MPCommerceEvent with a product impression.
+  CommerceEvent.withImpression({required Impression impression})
       : promotionActionType = null,
         productActionType = null {
     impressions.add(impression);
   }
 
+  /// A value from the ProductActionType enum describing the commerce event action.
   final ProductActionType? productActionType;
+
+  /// A value from the PromotionActionType enum describing the promotion action.
   final PromotionActionType? promotionActionType;
 
+  /// A list of internal promotions applied to the commerce action.
   final List<Promotion> promotions = [];
+
+  /// A list of products being applied to the commerce action.
   final List<Product> products = [];
+
+  /// A list of impressions being applied to the commerce action.
   final List<Impression> impressions = [];
 
+  /// The attributes of the transaction, such as: transactionId, tax, affiliation, shipping, etc.
   TransactionAttributes? transactionAttributes;
+
+  /// The checkout option string describing what the options are.
   String? checkoutOptions;
+
+  /// The currency used in the commerce event.
   String? currency;
+
+  /// Describes a product action list for this commerce event transaction.
   String? productListName;
+
+  /// Describes a product list source for this commerce event transaction.
   String? productListSource;
+
+  /// The label describing the screen on which the commerce event transaction occurred
   String? screenName;
+
+  /// The step number, within the chain of commerce event transactions, corresponding to the checkout.
   int? checkoutStep;
+
+  /// Flag indicating whether a refund is non-interactive.
   bool? nonInteractive;
+
+  /// Flag indicating whether the event should be sent to mParticle's servers.
   bool? shouldUploadEvent;
 
+  /// A map containing further information about the commerce event.
   Map<String, String?>? customAttributes;
+
+  /// A map containing kit-specific flags about the commerce event.
   Map<String, dynamic>? customFlags;
 }

--- a/lib/events/impression.dart
+++ b/lib/events/impression.dart
@@ -4,14 +4,18 @@ import 'package:mparticle_flutter_sdk/events/product.dart';
 ///
 /// An Impression assigns an [impressionListName] to a list of [products]
 class Impression {
-  Impression(this.impressionListName, this.products);
+  Impression({required this.impressionListName, required this.products});
 
-  final String impressionListName;
-  final List<Product> products;
+  /// A string name given to the list where the given Products displayed.
+  String impressionListName;
+
+  /// Product(s) to be associate with the Impression.
+  List<Product> products;
 
   static Impression fromJson(Map<String, dynamic> json) {
-    return Impression(json['impressionListName'] as String,
-        json['products'] as List<Product>);
+    return Impression(
+        impressionListName: json['impressionListName'] as String,
+        products: json['products'] as List<Product>);
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/events/mp_event.dart
+++ b/lib/events/mp_event.dart
@@ -2,11 +2,24 @@ import 'event_type.dart';
 
 /// This class represents an event to be logged using the mParticle SDK
 class MPEvent {
+  /// The name of the event to be logged. The event name must not contain more than 255 characters.
   String eventName;
+
+  /// An enum value that indicates the type of event to be logged.
   final EventType? eventType;
+
+  /// A map containing further information about the event.
   Map<String, String?>? customAttributes;
+
+  /// A map containing kit-specific flags about the event.
   Map<String, dynamic>? customFlags;
+
+  /// Flag indicating whether the event should be sent to mParticle's servers.
   bool? shouldUploadEvent;
 
-  MPEvent(this.eventName, [this.eventType]);
+  MPEvent(
+      {required this.eventName,
+      this.eventType,
+      this.customAttributes,
+      this.customFlags});
 }

--- a/lib/events/product.dart
+++ b/lib/events/product.dart
@@ -1,37 +1,59 @@
 /// A Product for use with a commerce event
 class Product {
-  Product(this.name, this.sku, this.price,
-      [this.quantity,
+  Product(
+      {required this.name,
+      required this.sku,
+      required this.price,
+      this.quantity,
       this.variant,
       this.category,
       this.brand,
       this.position,
       this.couponCode,
-      this.attributes]);
+      this.attributes});
 
+  /// The product name.
   final String name;
+
+  /// SKU of a product. This is the product id.
   final String sku;
-  final int? quantity;
+
+  /// The price of a product
   final double price;
+
+  /// The quantity of the product. Default value is 1.
+  final int? quantity;
+
+  /// The variant of the product.
   final String? variant;
+
+  /// A category to which the product belongs.
   final String? category;
+
+  /// The product brand.
   final String? brand;
+
+  /// The prosition of the product on the screen.
   final int? position;
+
+  /// The coupon associated with the product.
   final String? couponCode;
+
+  /// A map containing further information about the product.
   final Map<String, String?>? attributes;
 
   static Product fromJson(Map<String, dynamic> json) {
     return Product(
-        json['name'] as String,
-        json['sku'] as String,
-        json['price'] as double,
-        json['quantity'] as int,
-        json['variant'] as String,
-        json['category'] as String,
-        json['brand'] as String,
-        json['position'] as int,
-        json['couponCode'] as String,
-        json['attributes'] as Map<String, String?>);
+        name: json['name'] as String,
+        sku: json['sku'] as String,
+        price: json['price'] as double,
+        quantity: json['quantity'] as int,
+        variant: json['variant'] as String,
+        category: json['category'] as String,
+        brand: json['brand'] as String,
+        position: json['position'] as int,
+        couponCode: json['couponCode'] as String,
+        attributes: json['attributes'] as Map<String, String?>);
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/events/promotion.dart
+++ b/lib/events/promotion.dart
@@ -1,15 +1,26 @@
 /// A Promotion for use with a commerce event
 class Promotion {
-  Promotion(this.promotionId, [this.creative, this.name, this.position]);
+  Promotion(
+      {required this.promotionId, this.creative, this.name, this.position});
 
+  /// Promotion identifier
   final String promotionId;
+
+  /// Description for the promotion creative
   final String? creative;
+
+  /// Promotion name
   final String? name;
+
+  /// Promotion display position
   final String? position;
 
   static Promotion fromJson(Map<String, dynamic> json) {
-    return Promotion(json['promotionId'] as String, json['creative'] as String,
-        json['name'] as String, json['position'] as String);
+    return Promotion(
+        promotionId: json['promotionId'] as String,
+        creative: json['creative'] as String,
+        name: json['name'] as String,
+        position: json['position'] as String);
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/events/screen_event.dart
+++ b/lib/events/screen_event.dart
@@ -1,9 +1,15 @@
 /// This class represents a screen event to be logged using the mParticle SDK
 
 class ScreenEvent {
+  /// The name of the screen event to be logged.
   String eventName;
+
+  /// A map containing further information about the screen event.
   Map<String, String?>? customAttributes;
+
+  /// A map containing kit-specific flags about the screen event.
   Map<String, dynamic>? customFlags;
 
-  ScreenEvent(this.eventName);
+  ScreenEvent(
+      {required this.eventName, this.customAttributes, this.customFlags});
 }

--- a/lib/events/transaction_attributes.dart
+++ b/lib/events/transaction_attributes.dart
@@ -1,28 +1,40 @@
 /// This class represents the attributes of a commerce event transaction. It is used in conjunction with CommerceEvent.
 
 class TransactionAttributes {
-  TransactionAttributes(this.transactionId,
-      [this.affiliation,
+  TransactionAttributes(
+      {required this.transactionId,
+      this.affiliation,
       this.couponCode,
       this.shipping,
       this.tax,
-      this.revenue]);
+      this.revenue});
 
+  /// The unique identifier for the commerce event transaction.
   final String transactionId;
+
+  /// A string describing the affiliation.
   final String? affiliation;
+
+  /// The coupon code string.
   final String? couponCode;
+
+  ///The shipping amount of the commerce event transaction.
   final double? shipping;
+
+  /// The tax amount of the commerce event transaction.
   final double? tax;
+
+  /// The revenue amount of the commerce event transaction.
   final double? revenue;
 
   static TransactionAttributes fromJson(Map<String, dynamic> json) {
     return TransactionAttributes(
-        json['transactionId'] as String,
-        json['affiliation'] as String,
-        json['couponCode'] as String,
-        json['shipping'] as double,
-        json['tax'] as double,
-        json['revenue'] as double);
+        transactionId: json['transactionId'] as String,
+        affiliation: json['affiliation'] as String,
+        couponCode: json['couponCode'] as String,
+        shipping: json['shipping'] as double,
+        tax: json['tax'] as double,
+        revenue: json['revenue'] as double);
   }
 
   Map<String, dynamic> toJson() {

--- a/lib/identity/alias_request.dart
+++ b/lib/identity/alias_request.dart
@@ -4,13 +4,23 @@
 /// a [startTime] and [endTime], or exclude both and allow the underlying
 /// platform mParticle SDK to set them for you.
 class AliasRequest {
+  /// The MPID of the user that has existing data.
   String sourceMpid;
+
+  /// The MPID of the user that should receive the copied data.
   String destinationMpid;
+
+  /// The timestamp of the earliest data that should be copied, defaults to the source user’s first seen timestamp.
   int? startTime;
+
+  /// The timestamp of the latest data that should be copied, defaults to the source user’s last seen timestamp.
   int? endTime;
 
-  AliasRequest(this.sourceMpid, this.destinationMpid,
-      [this.endTime, this.startTime]);
+  AliasRequest(
+      {required this.sourceMpid,
+      required this.destinationMpid,
+      this.endTime,
+      this.startTime});
 
   setEndTime(endTime) {
     this.endTime = endTime;

--- a/lib/identity/client_error_codes.dart
+++ b/lib/identity/client_error_codes.dart
@@ -1,5 +1,4 @@
 /// A class of client error codes to be use with the IdentityApiErrorResponse class
-
 enum IdentityClientErrorCodes {
   RequestInProgress,
   ClientSideTimeout,

--- a/lib/identity/identity_api_error_response.dart
+++ b/lib/identity/identity_api_error_response.dart
@@ -4,13 +4,20 @@ import 'package:mparticle_flutter_sdk/identity/client_error_codes.dart';
 ///
 ///  This is passed to the handler for both client and server errors.
 class IdentityAPIErrorResponse {
+  /// The http response code for errors returned by the server.
   int? httpCode;
+
+  /// The MPID of the user.
   String? mpid;
+
+  /// Errors that are returned.  This can be client side, or server side.
   List<Error> errors = List.empty();
+
+  /// Client side error codes. If this exists, the Identity Request never was sent to the server.
   IdentityClientErrorCodes? clientErrorCode;
 
   IdentityAPIErrorResponse(
-      this.httpCode, this.mpid, this.errors, this.clientErrorCode);
+      {required this.errors, this.httpCode, this.mpid, this.clientErrorCode});
 
   @override
   String toString() {

--- a/lib/identity/identity_api_result.dart
+++ b/lib/identity/identity_api_result.dart
@@ -3,10 +3,13 @@ import 'package:mparticle_flutter_sdk/src/user.dart';
 /// A class that returns when an identity request succeeds.
 
 class IdentityApiResult {
+  /// Resolved user as a result of the Identity API request.
   late User user;
+
+  /// User that was active before identity request was sent, if applicable.
   User? previousUser;
 
-  IdentityApiResult(mpid, previousMpid) {
+  IdentityApiResult({required mpid, previousMpid}) {
     this.user = User(mpid);
     if (previousMpid != null) {
       this.previousUser = User(previousMpid);

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -165,9 +165,9 @@ class MparticleFlutterSdk {
   }
 
   /// Sets the opt out status with an [optOutBoolean]
-  Future<void> setOptOut({
-    required bool optOutBoolean,
-  }) async {
+  Future<void> setOptOut(
+    bool optOutBoolean,
+  ) async {
     return await _channel
         .invokeMethod('setOptOut', {'optOutBoolean': optOutBoolean});
   }
@@ -201,14 +201,15 @@ class MparticleFlutterSdk {
 class IdentityRequest {
   Map<IdentityType, String> identities = new Map();
 
-  IdentityRequest setIdentity(IdentityType identity, String value) {
-    this.identities[identity] = value;
+  IdentityRequest setIdentity(
+      {required IdentityType identityType, required String value}) {
+    this.identities[identityType] = value;
     return this;
   }
 
-  String? getIdentity(IdentityType identity) {
-    if (this.identities[identity] != null) {
-      return this.identities[identity];
+  String? getIdentity(IdentityType identityType) {
+    if (this.identities[identityType] != null) {
+      return this.identities[identityType];
     }
   }
 
@@ -224,30 +225,30 @@ class Identity {
   static const MethodChannel _channel =
       const MethodChannel('mparticle_flutter_sdk');
 
-  Future<IdentityApiResult> identify({
-    required IdentityRequest identityRequest,
-  }) async {
+  Future<IdentityApiResult> identify(
+    IdentityRequest identityRequest,
+  ) async {
     return await sendIdentityRequest(
         identityRequest.identities, _channel, 'identify');
   }
 
-  Future<IdentityApiResult> login({
-    required IdentityRequest identityRequest,
-  }) async {
+  Future<IdentityApiResult> login(
+    IdentityRequest identityRequest,
+  ) async {
     return await sendIdentityRequest(
         identityRequest.identities, _channel, 'login');
   }
 
-  Future<IdentityApiResult> logout({
-    required IdentityRequest identityRequest,
-  }) async {
+  Future<IdentityApiResult> logout(
+    IdentityRequest identityRequest,
+  ) async {
     return await sendIdentityRequest(
         identityRequest.identities, _channel, 'logout');
   }
 
-  Future<IdentityApiResult> modify({
-    required IdentityRequest identityRequest,
-  }) async {
+  Future<IdentityApiResult> modify(
+    IdentityRequest identityRequest,
+  ) async {
     return await sendIdentityRequest(
         identityRequest.identities, _channel, 'modify');
   }
@@ -255,7 +256,7 @@ class Identity {
   /// Transitions anonymous user to known user inside an `aliasRequest`
   ///
   /// See https://docs.mparticle.com/guides/idsync/aliasing/ for more information
-  Future<void> aliasUsers({required AliasRequest aliasRequest}) async {
+  Future<void> aliasUsers(AliasRequest aliasRequest) async {
     var aliasRequestObj = {
       "sourceMpid": aliasRequest.sourceMpid,
       "destinationMpid": aliasRequest.destinationMpid,

--- a/lib/src/identity/identity_helpers.dart
+++ b/lib/src/identity/identity_helpers.dart
@@ -76,18 +76,18 @@ sendIdentityRequest(Map<IdentityType, String> identitiesByEnum,
     }
 
     var error = IdentityAPIErrorResponse(
-        httpCode,
-        response["mpid"],
-        (response["errors"] as List?)
+        httpCode: httpCode,
+        mpid: response["mpid"],
+        errors: (response["errors"] as List?)
                 ?.map((e) => Error(e["code"], e["message"]))
                 .toList() ??
             List.empty(),
-        clientErrorCode);
+        clientErrorCode: clientErrorCode);
 
     return Future.error(error);
   } else {
-    var success =
-        IdentityApiResult(response["mpid"], response["previous_mpid"]);
+    var success = IdentityApiResult(
+        mpid: response["mpid"], previousMpid: response["previous_mpid"]);
     return success;
   }
 }

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -12,24 +12,25 @@ class User {
   String mpid;
   User(this.mpid);
 
+  /// Returns the user's MPID.
   String getMPID() {
     return this.mpid;
   }
 
   /// Returns the first time a user has been seen on the device.
-  void getFirstSeen(callback) async {
+  Future<int> getFirstSeen() async {
     String firstSeenTime =
         await _channel.invokeMethod('getFirstSeen', {"mpid": this.mpid});
 
-    callback(firstSeenTime);
+    return int.parse(firstSeenTime);
   }
 
   /// Returns the last time a user has been seen on the device.
-  void getLastSeen(callback) async {
+  Future<int> getLastSeen() async {
     String lastSeenTime =
         await _channel.invokeMethod('getLastSeen', {"mpid": this.mpid});
 
-    callback(lastSeenTime);
+    return int.parse(lastSeenTime);
   }
 
   /// Returns all user attributes.
@@ -58,7 +59,7 @@ class User {
   /// Increments a user attribute
   ///
   /// Increments a user attribute given a [key] by a given [value].
-  void incrementUserAttribute(String key, int value) async {
+  void incrementUserAttribute({required String key, required int value}) async {
     await _channel.invokeMethod('incrementUserAttribute',
         {"attributeKey": key, "attributeValue": value, "mpid": this.mpid});
   }
@@ -66,14 +67,14 @@ class User {
   /// Removes a user attribute.
   ///
   /// Removes a user attribute given a [key].
-  void removeUserAttribute(String key) async {
+  void removeUserAttribute({required String key}) async {
     await _channel.invokeMethod('removeUserAttribute', {"attributeKey": key});
   }
 
   /// Sets a user attribute.
   ///
   /// Sets a user attribute [key] given a [value].
-  void setUserAttribute(String key, String value) async {
+  void setUserAttribute({required String key, required String value}) async {
     await _channel.invokeMethod('setUserAttribute',
         {"attributeKey": key, "attributeValue": value, "mpid": this.mpid});
   }
@@ -81,7 +82,8 @@ class User {
   /// Sets a value of an array to a user attribute.
   ///
   /// Sets a user attribute [key] given a [value].
-  void setUserAttributeArray(String key, List<String> value) async {
+  void setUserAttributeArray(
+      {required String key, required List<String> value}) async {
     await _channel.invokeMethod('setUserAttributeArray',
         {"attributeKey": key, "attributeValue": value, "mpid": this.mpid});
   }
@@ -89,9 +91,9 @@ class User {
   /// Sets a user tag.
   ///
   /// Sets a given [tag] on a user. This sets a user attribute with a value of null.
-  void setUserTag(String key) async {
+  void setUserTag({required String tag}) async {
     await _channel
-        .invokeMethod('setUserTag', {"attributeKey": key, "mpid": this.mpid});
+        .invokeMethod('setUserTag', {"attributeKey": tag, "mpid": this.mpid});
   }
 
   /// Returns all GDPR Consent states with their purpose.
@@ -103,7 +105,7 @@ class User {
     consentStateMap.forEach((key, value) {
       Consent? consentState;
       if (value['consented'] != null) {
-        consentState = Consent(value['consented']);
+        consentState = Consent(consented: value['consented']);
         consentState.document = value['document'];
         consentState.hardwareId = value['hardwareId'];
         consentState.location = value['location'];
@@ -120,7 +122,8 @@ class User {
   /// Set a GDPR consent object to a purpose on the user
   ///
   /// Sets a GDPR consent object [consent] to a purpose [purpose] on the user
-  void addGDPRConsentState(Consent consent, String purpose) async {
+  void addGDPRConsentState(
+      {required Consent consent, required String purpose}) async {
     return await _channel.invokeMethod('addGDPRConsentState', {
       'consented': consent.consented,
       'document': consent.document,
@@ -135,7 +138,7 @@ class User {
   /// Remove a GDPR consent object from a purpose on the user
   ///
   /// Remove a GDPR consent object from a purpose [purpose] on the user
-  void removeGDPRConsentState(String purpose) async {
+  void removeGDPRConsentState({required String purpose}) async {
     return await _channel.invokeMethod('removeGDPRConsentState', {
       'purpose': purpose,
       'mpid': this.mpid,
@@ -149,7 +152,7 @@ class User {
     Map consentStateMap = jsonDecode(consentStateString);
     Consent? consentState;
     if (consentStateMap['consented'] != null) {
-      consentState = Consent(consentStateMap['consented']);
+      consentState = Consent(consented: consentStateMap['consented']);
       consentState.document = consentStateMap['document'];
       consentState.hardwareId = consentStateMap['hardwareId'];
       consentState.location = consentStateMap['location'];
@@ -163,7 +166,7 @@ class User {
   /// Set a CCPA consent object on the user
   ///
   /// Sets a CCPA consent object [consent] on the user
-  void addCCPAConsentState(Consent consent) async {
+  void addCCPAConsentState({required Consent consent}) async {
     return await _channel.invokeMethod('addCCPAConsentState', {
       'consented': consent.consented,
       'document': consent.document,

--- a/test/mparticle_flutter_sdk_test.dart
+++ b/test/mparticle_flutter_sdk_test.dart
@@ -34,9 +34,10 @@ void main() {
 
   group('mParticle Dart API Layer', () {
     test('logEvent', () async {
-      MPEvent event = MPEvent('Clicked Search Bar', EventType.Search)
-        ..customAttributes = {'key1': 'value1'}
-        ..customFlags = {'flag1': 'value1'};
+      MPEvent event =
+          MPEvent(eventName: 'Clicked Search Bar', eventType: EventType.Search)
+            ..customAttributes = {'key1': 'value1'}
+            ..customFlags = {'flag1': 'value1'};
 
       await mp.logEvent(event);
       expect(
@@ -60,7 +61,12 @@ void main() {
       final Product product2 =
           Product(name: 'Apple', sku: '456abc', price: 10.5, quantity: 2);
       final TransactionAttributes transactionAttributes = TransactionAttributes(
-          '123456', 'affiliation', '12412342', 1.34, 43.232, 242.2323);
+          transactionId: '123456',
+          affiliation: 'affiliation',
+          couponCode: '12412342',
+          shipping: 1.34,
+          tax: 43.232,
+          revenue: 242.2);
       CommerceEvent commerceEvent = CommerceEvent.withProduct(
           productActionType: ProductActionType.Purchase, product: product1)
         ..products.add(product2)
@@ -160,12 +166,15 @@ void main() {
     test('log impression commerce event', () async {
       final Product product1 =
           Product(name: 'Orange', sku: '123abc', price: 2.4, quantity: 1);
-      final Impression impression1 = Impression('produce', [product1]);
-      final Impression impression2 = Impression('citrus', [product1]);
-      CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
-        ..impressions.add(impression2)
-        ..currency = 'US'
-        ..screenName = 'One Click Purchase';
+      final Impression impression1 =
+          Impression(impressionListName: 'produce', products: [product1]);
+      final Impression impression2 =
+          Impression(impressionListName: 'citrus', products: [product1]);
+      CommerceEvent commerceEvent =
+          CommerceEvent.withImpression(impression: impression1)
+            ..impressions.add(impression2)
+            ..currency = 'US'
+            ..screenName = 'One Click Purchase';
       mp.logCommerceEvent(commerceEvent);
       expect(
         methodCall,
@@ -262,7 +271,8 @@ void main() {
     });
 
     test('alias users', () async {
-      var userAliasRequest = AliasRequest('sourceMPID', 'destinationMPID');
+      var userAliasRequest = AliasRequest(
+          sourceMpid: 'sourceMPID', destinationMpid: 'destinationMPID');
       userAliasRequest.setStartTime(123);
       userAliasRequest.setEndTime(456);
       mp.identity.aliasUsers(userAliasRequest);

--- a/test/mparticle_flutter_sdk_test.dart
+++ b/test/mparticle_flutter_sdk_test.dart
@@ -55,16 +55,18 @@ void main() {
     });
 
     test('log product action commerce event', () async {
-      final Product product1 = Product('Orange', '123abc', 5.0, 1);
-      final Product product2 = Product('Apple', '456abc', 10.5, 2);
+      final Product product1 =
+          Product(name: 'Orange', sku: '123abc', price: 5.0, quantity: 1);
+      final Product product2 =
+          Product(name: 'Apple', sku: '456abc', price: 10.5, quantity: 2);
       final TransactionAttributes transactionAttributes = TransactionAttributes(
           '123456', 'affiliation', '12412342', 1.34, 43.232, 242.2323);
-      CommerceEvent commerceEvent =
-          CommerceEvent.withProduct(ProductActionType.Purchase, product1)
-            ..products.add(product2)
-            ..transactionAttributes = transactionAttributes
-            ..currency = 'US'
-            ..screenName = 'One Click Purchase';
+      CommerceEvent commerceEvent = CommerceEvent.withProduct(
+          productActionType: ProductActionType.Purchase, product: product1)
+        ..products.add(product2)
+        ..transactionAttributes = transactionAttributes
+        ..currency = 'US'
+        ..screenName = 'One Click Purchase';
       mp.logCommerceEvent(commerceEvent);
       expect(
         methodCall,
@@ -96,16 +98,22 @@ void main() {
     });
 
     test('log promotion commerce event', () async {
-      final Promotion promotion1 =
-          Promotion('12312', 'Jennifer Slater', 'BOGO Bonanza', 'top');
-      final Promotion promotion2 =
-          Promotion('15632', 'Gregor Roman', 'Eco Living', 'mid');
+      final Promotion promotion1 = Promotion(
+          promotionId: '12312',
+          creative: 'Jennifer Slater',
+          name: 'BOGO Bonanza',
+          position: 'top');
+      final Promotion promotion2 = Promotion(
+          promotionId: '15632',
+          creative: 'Gregor Roman',
+          name: 'Eco Living',
+          position: 'mid');
 
-      CommerceEvent commerceEvent =
-          CommerceEvent.withPromotion(PromotionActionType.View, promotion1)
-            ..promotions.add(promotion2)
-            ..currency = 'US'
-            ..screenName = 'Promotion Screen Name';
+      CommerceEvent commerceEvent = CommerceEvent.withPromotion(
+          promotionActionType: PromotionActionType.View, promotion: promotion1)
+        ..promotions.add(promotion2)
+        ..currency = 'US'
+        ..screenName = 'Promotion Screen Name';
       mp.logCommerceEvent(commerceEvent);
       expect(
         methodCall,
@@ -150,7 +158,8 @@ void main() {
     });
 
     test('log impression commerce event', () async {
-      final Product product1 = Product('Orange', '123abc', 2.4, 1);
+      final Product product1 =
+          Product(name: 'Orange', sku: '123abc', price: 2.4, quantity: 1);
       final Impression impression1 = Impression('produce', [product1]);
       final Impression impression2 = Impression('citrus', [product1]);
       CommerceEvent commerceEvent = CommerceEvent.withImpression(impression1)
@@ -210,7 +219,7 @@ void main() {
     });
 
     test('log screen event', () async {
-      ScreenEvent screenEvent = ScreenEvent('Screen event logged')
+      ScreenEvent screenEvent = ScreenEvent(eventName: 'Screen event logged')
         ..customAttributes = {'key1': 'value1'}
         ..customFlags = {'flag1': 'value1'};
       mp.logScreenEvent(screenEvent);
@@ -237,7 +246,7 @@ void main() {
     });
 
     test('set opt out', () async {
-      mp.setOptOut(optOutBoolean: true);
+      mp.setOptOut(true);
       expect(
         methodCall,
         isMethodCall('setOptOut', arguments: {'optOutBoolean': true}),
@@ -256,7 +265,7 @@ void main() {
       var userAliasRequest = AliasRequest('sourceMPID', 'destinationMPID');
       userAliasRequest.setStartTime(123);
       userAliasRequest.setEndTime(456);
-      mp.identity.aliasUsers(aliasRequest: userAliasRequest);
+      mp.identity.aliasUsers(userAliasRequest);
       expect(
         methodCall,
         isMethodCall('aliasUsers', arguments: {


### PR DESCRIPTION
# Summary

Having named parameters is a much more readable and maintainable way for our users to implement our Flutter SDK.  This update contains 2 things:
* migrating to named parameters on every public method call
* docs for each public method and property - this will help our Docs score which gives us more "pub points" - current score found [here](https://pub.dev/packages/mparticle_flutter_sdk/score)