### PR TITLE
fix: Update removeUserAttribute, add support for web

### DIFF
--- a/lib/mparticle_flutter_sdk_web.dart
+++ b/lib/mparticle_flutter_sdk_web.dart
@@ -221,6 +221,10 @@ class MparticleFlutterSdkWeb {
             'setUserAttribute',
             [call.arguments["attributeKey"], call.arguments["attributeValue"]]);
         break;
+      case 'removeUserAttribute':
+        mpIdentity.callMethod('getUser', [call.arguments["mpid"]]).callMethod(
+            'removeUserAttribute', [call.arguments["attributeKey"]]);
+        break;
       case 'setUserAttributeArray':
         mpIdentity.callMethod('getUser', [call.arguments["mpid"]]).callMethod(
             'setUserAttributeList', [

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -68,7 +68,8 @@ class User {
   ///
   /// Removes a user attribute given a [key].
   void removeUserAttribute({required String key}) async {
-    await _channel.invokeMethod('removeUserAttribute', {"attributeKey": key});
+    await _channel.invokeMethod(
+        'removeUserAttribute', {"attributeKey": key, "mpid": this.mpid});
   }
 
   /// Sets a user attribute.


### PR DESCRIPTION
# Summary

We were not passing `mpid` from dart to the platforms, which is required to get the User to remove the attribute. Also we were missing support for removeUserAttribute from web.