### PR TITLE
Allow using Gradle 7.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.mparticle.mparticle_flutter_sdk'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Summary
- Bumping Kotlin Gradle Plugin to 1.5.20 to satisfy minimum required version by Gradle 7.3

## Testing Plan
- Tested locally in macOS and Windows

## Reference Issue
- Closes #33