### PR TITLE
chore: update podspec to ~> 8.21

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,7 +31,7 @@ target 'Runner' do
   use_frameworks!
   use_modular_headers!
 
-  pod 'mParticle-Apple-SDK', '~> 8.5.0'
+  pod 'mParticle-Apple-SDK', '~> 8.21'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/ios/mparticle_flutter_sdk.podspec
+++ b/ios/mparticle_flutter_sdk.podspec
@@ -9,14 +9,14 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 mParticle Flutter Wrapper
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://www.mparticle.com'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'mParticle' => 'support@mparticle.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.5'
-  s.platform = :ios, '8.0'
+  s.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.21'
+  s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
 ## Summary
 I updated
```ruby
s.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.21'
s.platform = :ios, '9.0'
```

I also amended
```ruby
s.author = { 'mParticle' => 'support@mparticle.com' }
```

 ## Testing Plan
 - [x] Tested with a local build using
  ```yaml
  mparticle_flutter_sdk:
    git:
      url: https://github.com/techouse/mparticle-flutter-sdk.git
      ref: chore/update-podspec
  ```
