### PR TITLE
fix: type 'Null' is not a subtype of type 'String' in getCurrentUser

### DIFF
--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -182,11 +182,11 @@ class MparticleFlutterSdk {
   }
 
   Future<User?> getCurrentUser() async {
-    String mpid = await _channel.invokeMethod('getMPID');
-    if (mpid == "") {
-      return null;
+    String? mpid = await _channel.invokeMethod('getMPID');
+    if (mpid != null && mpid.isNotEmpty) {
+      return new User(mpid);
     }
-    return new User(mpid);
+    return null;
   }
 
   Future<Map> getAttributions() async {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Currently the mParticle SDK has a null pointer bug when trying to retrieve the mpid on some Android devices.

 ## Testing Plan
 - I didn't test it locally, basically I just added a null check, an additional layer of protection to the existing check that only looks if the mpid is an empty string.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
- https://github.com/mParticle/mparticle-flutter-sdk/issues/45
