### PR TITLE
feat: SQDSDKS-7416 -Add RoktConfig support for selectPlacements in Flutter SDK

### DIFF
--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -1,5 +1,7 @@
 package com.mparticle.mparticle_flutter_sdk
 
+import android.content.Context
+import android.graphics.Typeface
 import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -40,11 +42,15 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
   private lateinit var channel: MethodChannel
   private val TAG = "MparticleFlutterSdkPlugin"
   private lateinit var layoutFactory: RoktLayoutFactory
+  private var flutterAssets: FlutterPlugin.FlutterAssets? = null
+  private var applicationContext: Context? = null
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "mparticle_flutter_sdk")
     channel.setMethodCallHandler(this)
     layoutFactory = RoktLayoutFactory(flutterPluginBinding.binaryMessenger)
+    flutterAssets = flutterPluginBinding.flutterAssets
+    applicationContext = flutterPluginBinding.applicationContext
     flutterPluginBinding.platformViewRegistry.registerViewFactory(
         VIEW_TYPE,
         layoutFactory,
@@ -692,6 +698,18 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
       val placeHolders: MutableMap<String, WeakReference<RoktEmbeddedView>> = mutableMapOf()
       val configMap = call.argument<HashMap<String, Any>>("config")
       val config = configMap?.let { buildRoktConfig(it) }
+      val customFonts = call.argument<HashMap<String, String>>("fontFilePathMap")
+        .orEmpty()
+        .mapNotNull { (key, fontPath) ->
+            applicationContext?.assets?.let { assets ->
+                flutterAssets?.getAssetFilePathByName(fontPath)?.let { assetPath ->
+                    runCatching {
+                        key to WeakReference(Typeface.createFromAsset(assets, assetPath))
+                    }.getOrNull()
+                }
+            }
+        }
+        .toMap()
 
       call.argument<HashMap<Int, String>>("placeholders")?.entries?.forEach { entry ->
         layoutFactory.nativeViews[entry.key]?.let { view ->
@@ -710,7 +728,7 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       MParticle.getInstance()?.let { instance ->
-        instance.Rokt().selectPlacements(placementId, stringAttributes, null, placeHolders.takeIf { it.isNotEmpty() }, null, config)
+        instance.Rokt().selectPlacements(placementId, stringAttributes, null, placeHolders.takeIf { it.isNotEmpty() }, customFonts, config)
         result.success(true)
       } ?: result.error(TAG, "No mParticle instance exists", null)
     } catch (e: Exception) {

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -8,8 +8,8 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-import com.mparticle.identity.AliasRequest;
-import com.mparticle.identity.IdentityApi;
+import com.mparticle.identity.AliasRequest
+import com.mparticle.identity.IdentityApi
 import com.mparticle.identity.IdentityApiRequest
 import com.mparticle.identity.IdentityApiResult
 import com.mparticle.identity.IdentityHttpResponse
@@ -22,6 +22,8 @@ import com.mparticle.commerce.*
 import com.mparticle.consent.CCPAConsent
 import com.mparticle.consent.ConsentState
 import com.mparticle.consent.GDPRConsent
+import com.mparticle.rokt.CacheConfig
+import com.mparticle.rokt.RoktConfig
 import com.mparticle.rokt.RoktEmbeddedView
 
 import org.json.JSONObject
@@ -688,6 +690,8 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
       val placementId: String? = call.argument("placementId")
       val attributes: Map<String, Any?>? = call.argument("attributes")
       val placeHolders: MutableMap<String, WeakReference<RoktEmbeddedView>> = mutableMapOf()
+      val configMap = call.argument<HashMap<String, Any>>("config")
+      val config = configMap?.let { buildRoktConfig(it) }
 
       call.argument<HashMap<Int, String>>("placeholders")?.entries?.forEach { entry ->
         layoutFactory.nativeViews[entry.key]?.let { view ->
@@ -706,13 +710,34 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       MParticle.getInstance()?.let { instance ->
-        instance.Rokt().selectPlacements(placementId, stringAttributes, null, placeHolders.takeIf { it.isNotEmpty() }, null, null)
+        instance.Rokt().selectPlacements(placementId, stringAttributes, null, placeHolders.takeIf { it.isNotEmpty() }, null, config)
         result.success(true)
       } ?: result.error(TAG, "No mParticle instance exists", null)
     } catch (e: Exception) {
       result.error(TAG, e.localizedMessage, null)
     }
   }
+
+  private fun buildRoktConfig(configMap: Map<String, Any>): RoktConfig {
+    val builder = RoktConfig.Builder()
+    (configMap["colorMode"] as? String)?.let {
+      builder.colorMode(it.toColorMode())
+    }
+    (configMap["cacheConfig"] as? Map<String, Any>)?.let { cacheConfig ->
+      val cacheDurationInSeconds = cacheConfig["cacheDurationInSeconds"] as? Int ?: 0
+      val cacheAttributes = cacheConfig["cacheAttributes"] as? Map<String, String> ?: null
+      builder.cacheConfig(CacheConfig(cacheDurationInSeconds.toLong(), cacheAttributes))
+    }
+
+    return builder.build()
+  }
+
+  private fun String.toColorMode(): RoktConfig.ColorMode =
+    when (this) {
+      "dark" -> RoktConfig.ColorMode.DARK
+      "light" -> RoktConfig.ColorMode.LIGHT
+      else -> RoktConfig.ColorMode.SYSTEM
+    }
 
   private fun ConvertIdentityHttpResponseToString(response: IdentityHttpResponse?): String {
     val map = mutableMapOf<String, Any?>()

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -7,14 +7,16 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
   fileprivate static let VIEW_CALL_DELEGATE = "rokt_sdk.rokt.com/rokt_layout"
   let roktLayoutFactory: RoktLayoutFactory
   let channel: FlutterMethodChannel
+  let registrar: FlutterPluginRegistrar
 
-  init(messenger: FlutterBinaryMessenger) {
+  init(messenger: FlutterBinaryMessenger, registrar: FlutterPluginRegistrar) {
     self.roktLayoutFactory = RoktLayoutFactory(messenger: messenger)
+    self.registrar = registrar
     self.channel = FlutterMethodChannel(name: "mparticle_flutter_sdk", binaryMessenger: messenger)
   }
 
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let instance = SwiftMparticleFlutterSdkPlugin(messenger: registrar.messenger())
+    let instance = SwiftMparticleFlutterSdkPlugin(messenger: registrar.messenger(), registrar: registrar)
     registrar.addMethodCallDelegate(instance, channel: instance.channel)
     registrar.register(instance.roktLayoutFactory, withId: SwiftMparticleFlutterSdkPlugin.VIEW_CALL_DELEGATE)
   }
@@ -502,7 +504,7 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
         MParticle._setWrapperSdk_internal(MPWrapperSdk.flutter, version: "")
     case "roktSelectPlacements":
         if let callArguments = call.arguments as? [String: Any],
-           let placementId = callArguments["placementId"] as? String {
+            let placementId = callArguments["placementId"] as? String {
             let attributes = callArguments["attributes"] as? [String: String] ?? [:]
 
             var placeholders: [String: MPRoktEmbeddedView] = [:]
@@ -530,6 +532,10 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
             if let configMap = callArguments["config"] as? [String: Any] {
                 roktConfig = buildRoktConfig(configMap: configMap)
             }
+            let fontFilePathMap = callArguments["fontFilePathMap"] as? Dictionary<String, String>
+            if let typefaces = fontFilePathMap {
+                registerPartnerFonts(typefaces)
+            }
 
             MParticle.sharedInstance().rokt.selectPlacements(placementId, attributes: attributes, placements: placeholders, config: roktConfig, callbacks: callback)
             result(true)
@@ -539,6 +545,20 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
         }
     default:
         print("mParticle flutter SDK for iOS does not support \(call.method)")
+    }
+  }
+
+  private func registerPartnerFonts(_ typefaces: Dictionary<String, String>) {
+    let bundle = Bundle.main
+    for (_, fileName) in typefaces {
+        let fontKey = registrar.lookupKey(forAsset: fileName)
+        let path = bundle.path(forResource: fontKey, ofType: nil)
+        var errorRef: Unmanaged<CFError>? = nil
+        guard let filePath = path, path?.isEmpty == false else {
+            continue
+        }
+        let fontUrl = NSURL(fileURLWithPath: filePath)
+        CTFontManagerRegisterFontsForURL(fontUrl, .process, &errorRef)
     }
   }
 }

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -525,8 +525,13 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
                     }
                 }
             }
+            
+            var roktConfig: MPRoktConfig?
+            if let configMap = callArguments["config"] as? [String: Any] {
+                roktConfig = buildRoktConfig(configMap: configMap)
+            }
 
-            MParticle.sharedInstance().rokt.selectPlacements(placementId, attributes: attributes, placements: placeholders, config: nil, callbacks: callback)
+            MParticle.sharedInstance().rokt.selectPlacements(placementId, attributes: attributes, placements: placeholders, config: roktConfig, callbacks: callback)
             result(true)
         } else {
             print("Incorrect argument for \(call.method) iOS method")
@@ -536,6 +541,37 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
         print("mParticle flutter SDK for iOS does not support \(call.method)")
     }
   }
+}
+
+private func buildRoktConfig(configMap: [String: Any]) -> MPRoktConfig? {
+    let config = MPRoktConfig()
+    var isConfigEmpty = true
+    
+    if let colorModeString = configMap["colorMode"] as? String {
+        if #available(iOS 12.0, *) {
+            isConfigEmpty = false
+            switch colorModeString {
+            case "dark":
+                if #available(iOS 13.0, *) {
+                    config.colorMode = .dark
+                }
+            case "light":
+                config.colorMode = .light
+            default: // "system"
+                config.colorMode = .system
+            }
+        }
+    }
+
+    if let cacheConfigMap = configMap["cacheConfig"] as? [String: Any] {
+        isConfigEmpty = false
+        let cacheDuration = cacheConfigMap["cacheDurationInSeconds"] as? NSNumber ?? 0
+        let cacheAttributes = cacheConfigMap["cacheAttributes"] as? [String: String]
+        config.cacheAttributes = cacheAttributes
+        config.cacheDuration = cacheDuration
+    }
+
+    return isConfigEmpty ? nil : config
 }
 
 private func asStringForStringKey(jsonDictionary: [String : Any]) -> String {

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -309,10 +309,12 @@ class Rokt {
   Future<void> selectPlacements({
     required String placementId,
     Map<String, dynamic>? attributes,
+    RoktConfig? roktConfig,
   }) async {
     var params = {
       'placementId': placementId,
       'attributes': attributes,
+      'config': _roktConfigToMap(config: roktConfig),
     };
 
     if (MparticleFlutterSdk._placeholders.isNotEmpty) {
@@ -320,4 +322,72 @@ class Rokt {
     }
     return await _channel.invokeMethod('roktSelectPlacements', params);
   }
+
+  Map<String, dynamic>? _roktConfigToMap({required RoktConfig? config}) {
+    if (config == null) {
+      return null;
+    }
+    return {
+      'colorMode': config.colorMode.name,
+      'cacheConfig': config.cacheConfig != null
+          ? {
+        'cacheDurationInSeconds': config.cacheConfig?.cacheDurationInSeconds,
+        'cacheAttributes': config.cacheConfig?.cacheAttributes
+      }
+          : null
+    };
+  }
+}
+
+/// Cache configuration for the Rokt SDK
+///
+/// - Attributes
+///  - [int] cacheDurationInSeconds: duration in seconds for which the Rokt SDK should cache the experience. Default is 90 minutes
+///  - [Map<String, String>]? cacheAttributes: optional attributes to be used as cache key. If null, all the attributes will be used as the cache key
+@immutable
+class CacheConfig {
+  /// Duration in seconds for which the Rokt SDK should cache the experience
+  final int cacheDurationInSeconds;
+  /// Optional attributes to be used as cache key
+  final Map<String, String>? cacheAttributes;
+
+  /// Constructor
+  ///
+  /// - Parameters
+  ///  - [int] cacheDurationInSeconds: duration in seconds for which the Rokt SDK should cache the experience. Default is 90 minutes
+  ///  - [Map<String, String>]? cacheAttributes: optional attributes to be used as cache key. If null, all the attributes will be used as the cache key
+  const CacheConfig(
+      {this.cacheDurationInSeconds = 0, this.cacheAttributes = null});
+}
+
+/// Configuration settings for the Rokt SDK <br>
+///
+/// - Attributes
+///   - [ColorMode]? colorMode: preferred device color mode configuration
+///   - [CacheConfig]? cacheConfig: cache configuration for the Rokt SDK
+@immutable
+class RoktConfig {
+  /// The device color mode your application is using
+  final ColorMode colorMode;
+  /// The cache configuration for the Rokt SDK
+  final CacheConfig? cacheConfig;
+
+  /// Constructor
+  ///
+  /// - Parameters
+  ///   - [ColorMode]? colorMode: preferred device color mode configuration
+  ///   - [CacheConfig]? cacheConfig: cache configuration for the Rokt SDK
+  const RoktConfig({this.colorMode = ColorMode.system, this.cacheConfig = null});
+}
+
+/// Enum representing device color modes
+enum ColorMode {
+  /// Request Light mode configuration
+  light,
+
+  /// Request Dark mode configuration
+  dark,
+
+  /// Request System's current configuration
+  system
 }

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -300,7 +300,7 @@ class Rokt {
   static const MethodChannel _channel =
       const MethodChannel('mparticle_flutter_sdk');
 
-  /// Selects placements with a [placementId] and optional [attributes].
+  /// Selects placements with a [placementId], optional [attributes], optional [roktConfig], and optional [fontFilePathMap].
   ///
   /// This method calls the Rokt selectPlacements API on each platform:
   /// - Web: mParticle.Rokt.selectPlacements()
@@ -310,11 +310,13 @@ class Rokt {
     required String placementId,
     Map<String, dynamic>? attributes,
     RoktConfig? roktConfig,
+    Map<String, String> fontFilePathMap = const {},
   }) async {
     var params = {
       'placementId': placementId,
       'attributes': attributes,
       'config': _roktConfigToMap(config: roktConfig),
+      'fontFilePathMap': fontFilePathMap,
     };
 
     if (MparticleFlutterSdk._placeholders.isNotEmpty) {

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -310,7 +310,7 @@ class Rokt {
     required String placementId,
     Map<String, dynamic>? attributes,
     RoktConfig? roktConfig,
-    Map<String, String> fontFilePathMap = const {},
+    Map<String, String>? fontFilePathMap,
   }) async {
     var params = {
       'placementId': placementId,


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Introduce `RoktConfig`, `CacheConfig`, and `ColorMode` classes in Dart.
- Update `selectPlacements` method to accept and pass `RoktConfig`.
- Implement native handling for `RoktConfig` in iOS and Android, including parsing and applying color mode and cache settings.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested by adding cache config in the flutter example app

https://github.com/user-attachments/assets/36b43e9e-be6d-41ff-b7aa-00c88d57e26c

https://github.com/user-attachments/assets/4e79781e-2496-4280-9155-abfb16adf319

Added support for customFonts
```dart
fontFilePathMap: {
  'Atop': 'fonts/Atop.ttf'
}
```
```yaml
  fonts:
    - family: Atop
      fonts:
        - asset: fonts/Atop.ttf
```
<img src="https://github.com/user-attachments/assets/81a17b04-5517-4cb5-be6d-f55c487a60b7" height="500" />



 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
