### PR TITLE
feat: Add support for Rokt event channel subscription

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -88,9 +88,13 @@ jobs:
   build-ios:
     needs: test
     name: Build iOS flutter app
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Xcode 16
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.3.0
       - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.mparticle:android-core:5+'
 
+    // Required for Rokt event subscription
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
+
     // Required for gathering Android Advertising ID (see below)
     implementation 'com.google.android.gms:play-services-ads-identifier:16.0.0'
 

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -1,5 +1,6 @@
 package com.mparticle.mparticle_flutter_sdk
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.Typeface
 import androidx.annotation.NonNull
@@ -27,6 +28,8 @@ import com.mparticle.consent.GDPRConsent
 import com.mparticle.rokt.CacheConfig
 import com.mparticle.rokt.RoktConfig
 import com.mparticle.rokt.RoktEmbeddedView
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 
 import org.json.JSONObject
 import kotlin.IllegalArgumentException
@@ -34,7 +37,7 @@ import java.lang.ref.WeakReference
 
 
 /** MparticleFlutterSdkPlugin */
-class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
+class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   /// The MethodChannel that will the communication between Flutter and native Android
   ///
   /// This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -44,6 +47,8 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
   private lateinit var layoutFactory: RoktLayoutFactory
   private var flutterAssets: FlutterPlugin.FlutterAssets? = null
   private var applicationContext: Context? = null
+  private var activity: Activity? = null
+  private var roktEventHandler: RoktEventHandler? = null
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "mparticle_flutter_sdk")
@@ -55,6 +60,7 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         VIEW_TYPE,
         layoutFactory,
     )
+    roktEventHandler = RoktEventHandler(flutterPluginBinding.binaryMessenger)
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -230,6 +236,22 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
         result.notImplemented()
       }
     }
+  }
+
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+    activity = null
+  }
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivity() {
+    activity = null
   }
 
   private fun logEvent(call: MethodCall, result: Result) {
@@ -728,6 +750,14 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       MParticle.getInstance()?.let { instance ->
+        activity?.let {
+          roktEventHandler?.subscribeToEvents(
+            events = instance.Rokt().events(placementId),
+            activity = it,
+            identifier = placementId,
+          )
+        }
+
         instance.Rokt().selectPlacements(placementId, stringAttributes, null, placeHolders.takeIf { it.isNotEmpty() }, customFonts, config)
         result.success(true)
       } ?: result.error(TAG, "No mParticle instance exists", null)

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -3,6 +3,7 @@ package com.mparticle.mparticle_flutter_sdk
 import android.app.Activity
 import android.content.Context
 import android.graphics.Typeface
+import android.os.Build
 import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -60,7 +61,9 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
         VIEW_TYPE,
         layoutFactory,
     )
-    roktEventHandler = RoktEventHandler(flutterPluginBinding.binaryMessenger)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          roktEventHandler = RoktEventHandler(flutterPluginBinding.binaryMessenger)
+      }
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -750,12 +753,14 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
       }
 
       MParticle.getInstance()?.let { instance ->
-        activity?.let {
-          roktEventHandler?.subscribeToEvents(
-            events = instance.Rokt().events(placementId),
-            activity = it,
-            identifier = placementId,
-          )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          activity?.let {
+            roktEventHandler?.subscribeToEvents(
+              events = instance.Rokt().events(placementId),
+              activity = it,
+              identifier = placementId,
+            )
+          }
         }
 
         instance.Rokt().selectPlacements(placementId, stringAttributes, null, placeHolders.takeIf { it.isNotEmpty() }, customFonts, config)

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/RoktEventHandler.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/RoktEventHandler.kt
@@ -1,0 +1,114 @@
+package com.mparticle.mparticle_flutter_sdk
+
+import android.app.Activity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.mparticle.RoktEvent
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.EventChannel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import java.util.ArrayDeque
+
+class RoktEventHandler(private val messenger: BinaryMessenger) {
+
+    private val eventListeners = mutableMapOf<Any?, ArrayDeque<EventChannel.EventSink>>()
+    private val eventSubscriptions = mutableMapOf<String, Job?>()
+
+    init {
+        setupEventChannel()
+    }
+
+    fun subscribeToEvents(events: Flow<RoktEvent>, identifier: String? = null, activity: Activity) {
+        val activeJob = eventSubscriptions[identifier.orEmpty()]?.takeIf { it.isActive }
+        if (activeJob != null) {
+            return
+        }
+        val owner = activity as? LifecycleOwner ?: return
+
+        val job = owner.lifecycleScope.launch {
+            owner.lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                events.collect { event ->
+                    val params = mutableMapOf<String, String>()
+
+                    params["event"] = event::class.simpleName ?: "RoktEvent"
+                    event.placementId?.let { params["placementId"] = it }
+
+                    when (event) {
+                        is RoktEvent.InitComplete -> {
+                            params["status"] = event.success.toString()
+                        }
+                        is RoktEvent.OpenUrl -> {
+                            params["url"] = event.url
+                        }
+                        is RoktEvent.CartItemInstantPurchase -> {
+                            params["cartItemId"] = event.cartItemId
+                            params["catalogItemId"] = event.catalogItemId
+                            params["currency"] = event.currency
+                            params["description"] = event.description
+                            params["linkedProductId"] = event.linkedProductId
+                            params["totalPrice"] = event.totalPrice.toString()
+                            params["quantity"] = event.quantity.toString()
+                            params["unitPrice"] = event.unitPrice.toString()
+                        }
+                        else -> {
+                            // No custom parameters needed for other events
+                        }
+                    }
+
+                    identifier?.let { params["identifier"] = it }
+                    eventListeners.values.flatten().forEach { listener -> listener.success(params) }
+                }
+            }
+        }
+        eventSubscriptions[identifier.orEmpty()] = job
+    }
+
+    private fun setupEventChannel() {
+        EventChannel(messenger, EVENT_CHANNEL_NAME).setStreamHandler(
+            object : EventChannel.StreamHandler {
+                override fun onListen(
+                    arguments: Any?,
+                    sink: EventChannel.EventSink?,
+                ) {
+                    sink?.let {
+                        val sinks = eventListeners.getOrPut(arguments) { ArrayDeque() }
+                        sinks.addLast(it)
+                    }
+                }
+
+                override fun onCancel(arguments: Any?) {
+                    val sinks = eventListeners[arguments]
+                    if (sinks?.isNotEmpty() == true) {
+                        sinks.removeLast()
+                    }
+                    if (sinks?.isEmpty() == true) {
+                        eventListeners.remove(arguments)
+                    }
+                }
+            },
+        )
+    }
+
+    private val RoktEvent.placementId: String?
+        get() = when (this) {
+            is RoktEvent.FirstPositiveEngagement -> placementId
+            is RoktEvent.OfferEngagement -> placementId
+            is RoktEvent.PlacementClosed -> placementId
+            is RoktEvent.PlacementCompleted -> placementId
+            is RoktEvent.PlacementFailure -> placementId
+            is RoktEvent.PlacementInteractive -> placementId
+            is RoktEvent.PlacementReady -> placementId
+            is RoktEvent.PositiveEngagement -> placementId
+            is RoktEvent.OpenUrl -> placementId
+            is RoktEvent.CartItemInstantPurchase -> placementId
+            else -> null
+        }
+
+    companion object {
+        private const val EVENT_CHANNEL_NAME = "MPRoktEvents"
+    }
+}

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/RoktEventHandler.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/RoktEventHandler.kt
@@ -1,6 +1,8 @@
 package com.mparticle.mparticle_flutter_sdk
 
 import android.app.Activity
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -11,11 +13,13 @@ import io.flutter.plugin.common.EventChannel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedDeque
 
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 class RoktEventHandler(private val messenger: BinaryMessenger) {
 
-    private val eventListeners = mutableMapOf<Any?, ArrayDeque<EventChannel.EventSink>>()
+    private val eventListeners = ConcurrentHashMap<Any?, ConcurrentLinkedDeque<EventChannel.EventSink>>()
     private val eventSubscriptions = mutableMapOf<String, Job?>()
 
     init {
@@ -75,18 +79,18 @@ class RoktEventHandler(private val messenger: BinaryMessenger) {
                     sink: EventChannel.EventSink?,
                 ) {
                     sink?.let {
-                        val sinks = eventListeners.getOrPut(arguments) { ArrayDeque() }
+                        val sinks = eventListeners.getOrPut(arguments ?: "") { ConcurrentLinkedDeque() }
                         sinks.addLast(it)
                     }
                 }
 
                 override fun onCancel(arguments: Any?) {
-                    val sinks = eventListeners[arguments]
+                    val sinks = eventListeners[arguments ?: ""]
                     if (sinks?.isNotEmpty() == true) {
                         sinks.removeLast()
                     }
                     if (sinks?.isEmpty() == true) {
-                        eventListeners.remove(arguments)
+                        eventListeners.remove(arguments ?: "")
                     }
                 }
             },

--- a/example/lib/rokt_layouts_screen.dart
+++ b/example/lib/rokt_layouts_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/services.dart';
 import 'dart:io' show Platform;
 import 'package:mparticle_flutter_sdk/mparticle_flutter_sdk.dart';
 import 'package:mparticle_flutter_sdk/identity/identity_type.dart';
@@ -18,6 +19,7 @@ class RoktLayoutsScreen extends StatefulWidget {
 class _RoktLayoutsScreenState extends State<RoktLayoutsScreen> {
   final TextEditingController _placementIdController =
       TextEditingController(text: 'readmorelayout');
+  final EventChannel roktEventChannel = EventChannel('MPRoktEvents');
 
   Map<String, String> _getAttributesForPlatform() {
     if (kIsWeb) {
@@ -72,9 +74,21 @@ class _RoktLayoutsScreenState extends State<RoktLayoutsScreen> {
   }
 
   @override
+  void initState() {
+    _receiveRoktEvent();
+    super.initState();
+  }
+
+  @override
   void dispose() {
     _placementIdController.dispose();
     super.dispose();
+  }
+
+  void _receiveRoktEvent() {
+    roktEventChannel.receiveBroadcastStream().listen((dynamic event) {
+      debugPrint("rokt_event: _receiveRoktEvent $event ");
+    });
   }
 
   Widget buildButton(String text, VoidCallback onPressed) {

--- a/ios/Classes/RoktEventHandler.swift
+++ b/ios/Classes/RoktEventHandler.swift
@@ -18,6 +18,7 @@ import mParticle_Apple_SDK
 class RoktEventHandler: NSObject, FlutterStreamHandler {
 
     private var eventListeners: [String: [FlutterEventSink]] = [:]
+    private let eventQueue = DispatchQueue(label: "com.mparticle.rokt.event.queue")
     private let EVENT_CHANNEL_NAME = "MPRoktEvents"
 
     init(messenger: FlutterBinaryMessenger) {
@@ -31,21 +32,25 @@ class RoktEventHandler: NSObject, FlutterStreamHandler {
     }
 
     func onListen(withArguments arguments: Any?, eventSink: @escaping FlutterEventSink) -> FlutterError? {
-        let key = String(describing: arguments ?? "nil")
-        var sinks = eventListeners[key] ?? []
-        sinks.append(eventSink)
-        eventListeners[key] = sinks
+        eventQueue.sync {
+            let key = String(describing: arguments ?? "nil")
+            var sinks = eventListeners[key] ?? []
+            sinks.append(eventSink)
+            eventListeners[key] = sinks
+        }
         return nil
     }
 
     func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        let key = String(describing: arguments ?? "nil")
-        if var sinks = eventListeners[key], !sinks.isEmpty {
-            sinks.removeLast()
-            if sinks.isEmpty {
-                eventListeners.removeValue(forKey: key)
-            } else {
-                eventListeners[key] = sinks
+        eventQueue.sync {
+            let key = String(describing: arguments ?? "nil")
+            if var sinks = eventListeners[key], !sinks.isEmpty {
+                sinks.removeLast()
+                if sinks.isEmpty {
+                    eventListeners.removeValue(forKey: key)
+                } else {
+                    eventListeners[key] = sinks
+                }
             }
         }
         return nil
@@ -81,8 +86,14 @@ class RoktEventHandler: NSObject, FlutterStreamHandler {
                 break
             }
 
-            self.eventListeners.values.joined().forEach { listener in
-                listener(params)
+            let allSinks = self.eventQueue.sync {
+                return Array(self.eventListeners.values.joined())
+            }
+
+            allSinks.forEach { listener in
+                DispatchQueue.main.async {
+                    listener(params)
+                }
             }
         }
     }

--- a/ios/Classes/RoktEventHandler.swift
+++ b/ios/Classes/RoktEventHandler.swift
@@ -1,0 +1,107 @@
+//
+//  RoktEventHandler.swift
+//  rokt_sdk
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+import Flutter
+import mParticle_Apple_SDK
+
+class RoktEventHandler: NSObject, FlutterStreamHandler {
+
+    private var eventListeners: [String: [FlutterEventSink]] = [:]
+    private let EVENT_CHANNEL_NAME = "MPRoktEvents"
+
+    init(messenger: FlutterBinaryMessenger) {
+        super.init()
+        setupEventChannel(messenger: messenger)
+    }
+
+    private func setupEventChannel(messenger: FlutterBinaryMessenger) {
+        let eventChannel = FlutterEventChannel(name: EVENT_CHANNEL_NAME, binaryMessenger: messenger)
+        eventChannel.setStreamHandler(self)
+    }
+
+    func onListen(withArguments arguments: Any?, eventSink: @escaping FlutterEventSink) -> FlutterError? {
+        let key = String(describing: arguments ?? "nil")
+        var sinks = eventListeners[key] ?? []
+        sinks.append(eventSink)
+        eventListeners[key] = sinks
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        let key = String(describing: arguments ?? "nil")
+        if var sinks = eventListeners[key], !sinks.isEmpty {
+            sinks.removeLast()
+            if sinks.isEmpty {
+                eventListeners.removeValue(forKey: key)
+            } else {
+                eventListeners[key] = sinks
+            }
+        }
+        return nil
+    }
+
+
+    func subscribeToEvents(identifier: String) {
+        MParticle.sharedInstance().rokt.events(identifier) { event in
+            var params: [String: String] = [:]
+
+            params["event"] = String(describing: type(of: event)).replacingOccurrences(of: "MPRokt", with: "").replacingOccurrences(of: "Event", with: "")
+            params["identifier"] = identifier
+
+            if let placementId = event.roktPlacementId {
+                params["placementId"] = placementId
+            }
+            
+            switch event {
+            case let initCompleteEvent as MPRoktEvent.MPRoktInitComplete:
+                params["status"] = initCompleteEvent.success ? "true" : "false"
+            case let openUrlEvent as MPRoktEvent.MPRoktOpenUrl:
+                params["url"] = openUrlEvent.url
+            case let cartItemInstantPurchaseEvent as MPRoktEvent.MPRoktCartItemInstantPurchase:
+                params["cartItemId"] = cartItemInstantPurchaseEvent.cartItemId
+                params["catalogItemId"] = cartItemInstantPurchaseEvent.catalogItemId
+                params["currency"] = cartItemInstantPurchaseEvent.currency
+                params["description"] = cartItemInstantPurchaseEvent.description
+                params["linkedProductId"] = cartItemInstantPurchaseEvent.linkedProductId
+                params["totalPrice"] = cartItemInstantPurchaseEvent.totalPrice?.stringValue
+                params["quantity"] = cartItemInstantPurchaseEvent.quantity?.stringValue
+                params["unitPrice"] = cartItemInstantPurchaseEvent.unitPrice?.stringValue
+            default:
+                break
+            }
+
+            self.eventListeners.values.joined().forEach { listener in
+                listener(params)
+            }
+        }
+    }
+}
+
+private extension MPRoktEvent {
+    var roktPlacementId: String? {
+        switch self {
+        case let event as MPRoktEvent.MPRoktFirstPositiveEngagement: return event.placementId
+        case let event as MPRoktEvent.MPRoktOfferEngagement: return event.placementId
+        case let event as MPRoktEvent.MPRoktPlacementClosed: return event.placementId
+        case let event as MPRoktEvent.MPRoktPlacementCompleted: return event.placementId
+        case let event as MPRoktEvent.MPRoktPlacementFailure: return event.placementId
+        case let event as MPRoktEvent.MPRoktPlacementInteractive: return event.placementId
+        case let event as MPRoktEvent.MPRoktPlacementReady: return event.placementId
+        case let event as MPRoktEvent.MPRoktPositiveEngagement: return event.placementId
+        case let event as MPRoktEvent.MPRoktOpenUrl: return event.placementId
+        case let event as MPRoktEvent.MPRoktCartItemInstantPurchase: return event.placementId
+        default: return nil
+        }
+    }
+}

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -8,11 +8,13 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
   let roktLayoutFactory: RoktLayoutFactory
   let channel: FlutterMethodChannel
   let registrar: FlutterPluginRegistrar
+  private let roktEventHandler: RoktEventHandler
 
   init(messenger: FlutterBinaryMessenger, registrar: FlutterPluginRegistrar) {
     self.roktLayoutFactory = RoktLayoutFactory(messenger: messenger)
     self.registrar = registrar
     self.channel = FlutterMethodChannel(name: "mparticle_flutter_sdk", binaryMessenger: messenger)
+    self.roktEventHandler = RoktEventHandler(messenger: messenger)
   }
 
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -537,7 +539,8 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
                 registerPartnerFonts(typefaces)
             }
 
-            MParticle.sharedInstance().rokt.selectPlacements(placementId, attributes: attributes, placements: placeholders, config: roktConfig, callbacks: callback)
+            roktEventHandler.subscribeToEvents(identifier: placementId)
+            MParticle.sharedInstance().rokt.selectPlacements(placementId, attributes: attributes, embeddedViews: placeholders, config: roktConfig, callbacks: callback)
             result(true)
         } else {
             print("Incorrect argument for \(call.method) iOS method")


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Add `RoktEventHandler` to forward native Rokt events to Flutter.
- Use an `EventChannel` to stream events from the native Android and iOS side.
- Add `lifecycle-runtime-ktx` dependency to safely collect events tied to the Activity lifecycle.
- Make the plugin `ActivityAware` to get the required Activity context.
- Add iOS events API and use the callback to subscribe to events and map them to the Flutter side.
- Update the example app to demonstrate listening for Rokt events.


 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
**iOS**

https://github.com/user-attachments/assets/26702385-89fe-48c2-bf34-dfe44d438a51

**Android**

https://github.com/user-attachments/assets/52b39267-309f-46c0-a5df-2664c952811a

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes [SQDSDKS-7415](https://mparticle-eng.atlassian.net/browse/SQDSDKS-7415)


[SQDSDKS-7415]: https://mparticle-eng.atlassian.net/browse/SQDSDKS-7415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ