### PR TITLE
fix: Add dart-lang/setup-dart for OIDC pub.dev publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,9 +29,15 @@ jobs:
     name: Publish and Release
     needs: [build-android, build-ios]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2c4a1885fabab # v1
 
       - name: Setup Flutter
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
@@ -42,7 +48,7 @@ jobs:
 
       - name: Publish Package
         run: |
-          flutter pub publish --force
+          dart pub publish --force
 
       - uses: ffurrer2/extract-release-notes@cae32133495112d23e3569ad04fef240ba4e7bc8 # v2
         id: extract-release-notes

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish Package
         run: |
-          dart pub publish --force
+          flutter pub publish --force
 
       - uses: ffurrer2/extract-release-notes@cae32133495112d23e3569ad04fef240ba4e7bc8 # v2
         id: extract-release-notes


### PR DESCRIPTION
## Background
- The Release – Publish workflow fails at the flutter pub publish step because the OIDC token exchange with pub.dev is not being handled automatically. The workflow prompts for interactive Google OAuth instead of using the GitHub Actions OIDC token.

## What Has Changed
- Added dart-lang/setup-dart action before Flutter setup — this action configures the OIDC token exchange with pub.dev when id-token: write permission is present
- Added explicit permissions: id-token: write on the release job level to ensure the OIDC token is available
- Kept flutter pub publish --force (required for Flutter SDK packages)

## Screenshots/Video
- N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- The pub.dev trusted publisher is already configured for mParticle/mparticle-flutter-sdk with tag pattern v{{version}}
- This needs to be merged and the v1.1.2 tag re-pushed to test the full flow

## Reference Issue (For employees only. Ignore if you are an outside contributor)
- N/A