### PR TITLE
feat: add iOS shoppable ads interface for Rokt

### DIFF
--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -235,6 +235,7 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
         result.success(true)
       }
       "roktSelectPlacements" -> this.roktSelectPlacements(call, result)
+      "roktSelectShoppableAds" -> this.roktSelectShoppableAds(call, result)
       "roktPurchaseFinalized" -> this.roktPurchaseFinalized(call, result)
       else -> {
         result.notImplemented()
@@ -804,6 +805,11 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
         null,
       )
     }
+  }
+
+  private fun roktSelectShoppableAds(call: MethodCall, result: Result) {
+    // Parity with RN bridge: Android API is exposed but not implemented yet.
+    result.success(true)
   }
 
   private fun String.toColorMode(): RoktConfig.ColorMode =

--- a/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/mparticle/mparticle_flutter_sdk/MparticleFlutterSdkPlugin.kt
@@ -26,6 +26,7 @@ import com.mparticle.commerce.*
 import com.mparticle.consent.CCPAConsent
 import com.mparticle.consent.ConsentState
 import com.mparticle.consent.GDPRConsent
+import com.mparticle.internal.Logger
 import com.mparticle.rokt.CacheConfig
 import com.mparticle.rokt.RoktConfig
 import com.mparticle.rokt.RoktEmbeddedView
@@ -809,6 +810,7 @@ class MparticleFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware
 
   private fun roktSelectShoppableAds(call: MethodCall, result: Result) {
     // Parity with RN bridge: Android API is exposed but not implemented yet.
+    Logger.warning("selectShoppableAds is not yet supported on Android")
     result.success(true)
   }
 

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -563,16 +563,16 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
         }
     case "roktSelectShoppableAds":
         if let callArguments = call.arguments as? [String: Any],
-           let placementId = callArguments["placementId"] as? String {
+           let identifier = callArguments["identifier"] as? String {
             let attributes = callArguments["attributes"] as? [String: String] ?? [:]
             var roktConfig: RoktConfig?
             if let configMap = callArguments["config"] as? [String: Any] {
                 roktConfig = buildRoktConfig(configMap: configMap)
             }
 
-            roktEventHandler.subscribeToEvents(identifier: placementId)
+            roktEventHandler.subscribeToEvents(identifier: identifier)
             MParticle.sharedInstance().rokt.selectShoppableAds(
-                placementId,
+                identifier,
                 attributes: attributes,
                 config: roktConfig
             ) { _ in
@@ -581,7 +581,7 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
             result(true)
         } else {
             print("Incorrect argument for \(call.method) iOS method")
-            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing placementId", details: nil))
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing identifier", details: nil))
         }
     default:
         print("mParticle flutter SDK for iOS does not support \(call.method)")

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -574,10 +574,9 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
             MParticle.sharedInstance().rokt.selectShoppableAds(
                 identifier,
                 attributes: attributes,
-                config: roktConfig
-            ) { _ in
-                // Event propagation is handled by subscribeToEvents(identifier:)
-            }
+                config: roktConfig,
+                onEvent: nil
+            )
             result(true)
         } else {
             print("Incorrect argument for \(call.method) iOS method")

--- a/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
+++ b/ios/Classes/SwiftMparticleFlutterSdkPlugin.swift
@@ -561,6 +561,28 @@ public class SwiftMparticleFlutterSdkPlugin: NSObject, FlutterPlugin {
             print("Incorrect argument for \(call.method) iOS method")
             result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing placementId or catalogItemId or success", details: nil))
         }
+    case "roktSelectShoppableAds":
+        if let callArguments = call.arguments as? [String: Any],
+           let placementId = callArguments["placementId"] as? String {
+            let attributes = callArguments["attributes"] as? [String: String] ?? [:]
+            var roktConfig: RoktConfig?
+            if let configMap = callArguments["config"] as? [String: Any] {
+                roktConfig = buildRoktConfig(configMap: configMap)
+            }
+
+            roktEventHandler.subscribeToEvents(identifier: placementId)
+            MParticle.sharedInstance().rokt.selectShoppableAds(
+                placementId,
+                attributes: attributes,
+                config: roktConfig
+            ) { _ in
+                // Event propagation is handled by subscribeToEvents(identifier:)
+            }
+            result(true)
+        } else {
+            print("Incorrect argument for \(call.method) iOS method")
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Missing placementId", details: nil))
+        }
     default:
         print("mParticle flutter SDK for iOS does not support \(call.method)")
     }

--- a/ios/mparticle_flutter_sdk.podspec
+++ b/ios/mparticle_flutter_sdk.podspec
@@ -15,10 +15,8 @@ mParticle Flutter Wrapper
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  # SDK 9.0 split requires both umbrella and ObjC pods.
+  # SDK 9.0 umbrella pod pulls required transitive dependencies.
   s.dependency 'mParticle-Apple-SDK', '~> 9.0'
-  s.dependency 'mParticle-Apple-SDK-ObjC', '~> 9.0'
-  s.dependency 'RoktContracts', '~> 0.1'
   s.platform = :ios, '15.6'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -331,6 +331,22 @@ class Rokt {
     return await _channel.invokeMethod('roktSelectPlacements', params);
   }
 
+  /// Selects shoppable ads with a [identifier], optional [attributes], and optional [roktConfig].
+  ///
+  /// This method currently has native implementation on iOS.
+  /// Android keeps a no-op bridge for cross-platform API compatibility.
+  Future<void> selectShoppableAds({
+    required String identifier,
+    Map<String, dynamic>? attributes,
+    RoktConfig? roktConfig,
+  }) async {
+    return await _channel.invokeMethod('roktSelectShoppableAds', {
+      'placementId': identifier,
+      'attributes': attributes,
+      'config': _roktConfigToMap(config: roktConfig),
+    });
+  }
+
   /// Notifies Rokt that a purchase has been finalized
   ///
   /// Use this method to inform Rokt that a purchase has been completed or failed

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -343,7 +343,7 @@ class Rokt {
     RoktConfig? roktConfig,
   }) async {
     return await _channel.invokeMethod('roktSelectShoppableAds', {
-      'placementId': identifier,
+      'identifier': identifier,
       'attributes': attributes,
       'config': _roktConfigToMap(config: roktConfig),
     });

--- a/lib/mparticle_flutter_sdk.dart
+++ b/lib/mparticle_flutter_sdk.dart
@@ -333,8 +333,10 @@ class Rokt {
 
   /// Selects shoppable ads with a [identifier], optional [attributes], and optional [roktConfig].
   ///
-  /// This method currently has native implementation on iOS.
-  /// Android keeps a no-op bridge for cross-platform API compatibility.
+  /// This method is currently implemented only on iOS.
+  ///
+  /// Android keeps a no-op bridge for API compatibility, and web does not
+  /// implement this method yet.
   Future<void> selectShoppableAds({
     required String identifier,
     Map<String, dynamic>? attributes,

--- a/lib/mparticle_flutter_sdk_web.dart
+++ b/lib/mparticle_flutter_sdk_web.dart
@@ -536,18 +536,6 @@ class MparticleFlutterSdkWeb {
           })
         ]);
         break;
-      case 'roktSelectShoppableAds':
-        final mpRokt = JsObject.fromBrowserObject(context['mParticle']['Rokt']);
-        final placementId = call.arguments['placementId'];
-        final attributes = call.arguments['attributes'] ?? {};
-
-        mpRokt.callMethod('selectShoppableAds', [
-          JsObject.jsify({
-            'identifier': placementId,
-            'attributes': attributes
-          })
-        ]);
-        break;
       default:
         throw PlatformException(
           code: 'Unimplemented',

--- a/lib/mparticle_flutter_sdk_web.dart
+++ b/lib/mparticle_flutter_sdk_web.dart
@@ -536,6 +536,18 @@ class MparticleFlutterSdkWeb {
           })
         ]);
         break;
+      case 'roktSelectShoppableAds':
+        final mpRokt = JsObject.fromBrowserObject(context['mParticle']['Rokt']);
+        final placementId = call.arguments['placementId'];
+        final attributes = call.arguments['attributes'] ?? {};
+
+        mpRokt.callMethod('selectShoppableAds', [
+          JsObject.jsify({
+            'identifier': placementId,
+            'attributes': attributes
+          })
+        ]);
+        break;
       default:
         throw PlatformException(
           code: 'Unimplemented',

--- a/test/mparticle_flutter_sdk_test.dart
+++ b/test/mparticle_flutter_sdk_test.dart
@@ -511,7 +511,7 @@ void main() {
               cacheAttributes: {'key1': 'value1'}));
 
       await mp.rokt.selectShoppableAds(
-        identifier: 'placement1',
+        identifier: 'identifier1',
         attributes: {'attr1': 'val1'},
         roktConfig: roktConfig,
       );
@@ -519,7 +519,7 @@ void main() {
       expect(
           methodCall,
           isMethodCall('roktSelectShoppableAds', arguments: {
-            'placementId': 'placement1',
+            'identifier': 'identifier1',
             'attributes': {'attr1': 'val1'},
             'config': {
               'colorMode': 'dark',

--- a/test/mparticle_flutter_sdk_test.dart
+++ b/test/mparticle_flutter_sdk_test.dart
@@ -502,5 +502,33 @@ void main() {
             'success': true,
           }));
     });
+
+    test('rokt select shoppable ads', () async {
+      final roktConfig = RoktConfig(
+          colorMode: ColorMode.dark,
+          cacheConfig: CacheConfig(
+              cacheDurationInSeconds: 100,
+              cacheAttributes: {'key1': 'value1'}));
+
+      await mp.rokt.selectShoppableAds(
+        identifier: 'placement1',
+        attributes: {'attr1': 'val1'},
+        roktConfig: roktConfig,
+      );
+
+      expect(
+          methodCall,
+          isMethodCall('roktSelectShoppableAds', arguments: {
+            'placementId': 'placement1',
+            'attributes': {'attr1': 'val1'},
+            'config': {
+              'colorMode': 'dark',
+              'cacheConfig': {
+                'cacheDurationInSeconds': 100,
+                'cacheAttributes': {'key1': 'value1'}
+              }
+            },
+          }));
+    });
   });
 }


### PR DESCRIPTION
## Background
This change introduces the Flutter API surface needed for shoppable ads while keeping behavior aligned with currently supported platforms.
The implementation is scoped to iOS support, with Android exposed as a compatibility no-op.

## What Has Changed
- Added `selectShoppableAds` to the Flutter Rokt API and method channel flow
- Implemented iOS native bridge handling for `roktSelectShoppableAds`
- Added Android no-op handler for cross-platform API compatibility
- Updated iOS podspec to keep only the SDK umbrella dependency and rely on transitive pods
- Added test coverage for the new Flutter method call contract

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
`selectShoppableAds` is currently iOS-only. Android is intentionally a no-op and web is not implemented.


Made with [Cursor](https://cursor.com)