### PR TITLE
docs: align Flutter native dependency versions for CNAME updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Apple SDK `MPNetworkOptions.customBaseURL` configuration in iOS initialization examples for CNAME routing.
+- Add Android initialization examples for CNAME routing via `NetworkOptions.withNetworkOptions(...)`.
+
+### Changed
+
+- Bump iOS CocoaPods dependency from `mParticle-Apple-SDK ~> 9.1` to `~> 9.2`.
+- Pin Android Gradle dependencies in plugin/example docs to `android-core:5.79.0` and `android-rokt-kit:5.79.0`.
+
 ## [2.0.0] - 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ To install mParticle on an Android platform:
 
 ```groovy
 dependencies {
-    implementation 'com.mparticle:android-core:5+'
+    implementation 'com.mparticle:android-core:5.79.0'
+    // Required only if you use Rokt APIs from Flutter
+    implementation 'com.mparticle:android-rokt-kit:5.79.0'
 
     // Required for gathering Android Advertising ID (see below)
     implementation 'com.google.android.gms:play-services-ads-identifier:16.0.0'
@@ -63,6 +65,8 @@ package com.example.myapp;
 
 import android.app.Application;
 import com.mparticle.MParticle;
+import com.mparticle.MParticleOptions;
+import com.mparticle.networking.NetworkOptions;
 
 public class MyApplication extends Application {
     @Override
@@ -70,6 +74,7 @@ public class MyApplication extends Application {
         super.onCreate();
         MParticleOptions options = MParticleOptions.builder(this)
             .credentials("REPLACE ME WITH KEY","REPLACE ME WITH SECRET")
+            .networkOptions(NetworkOptions.withNetworkOptions("https://rkt.example.com"))
             .setLogLevel(MParticle.LogLevel.VERBOSE)
             .identify(identifyRequest)
             .identifyTask(
@@ -88,12 +93,14 @@ public class MyApplication extends Application {
 ```kotlin
 import com.mparticle.MParticle
 import com.mparticle.MParticleOptions
+import com.mparticle.networking.NetworkOptions
 
 class ExampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         val options = MParticleOptions.builder(this)
             .credentials("REPLACE ME WITH KEY", "REPLACE ME WITH SECRET")
+            .networkOptions(NetworkOptions.withNetworkOptions("https://rkt.example.com"))
             .build()
         MParticle.start(options)
     }
@@ -117,7 +124,7 @@ To install mParticle on an iOS platform:
 2. Install the SDK using CocoaPods:
 
 ```bash
-$ # Update your Podfile to depend on 'mParticle-Apple-SDK' version 9.1.0 or later
+$ # Update your Podfile to depend on 'mParticle-Apple-SDK' version 9.2.0 or later
 $ pod install
 ```
 
@@ -136,6 +143,9 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions lau
         
        // Override point for customization after application launch.
         let mParticleOptions = MParticleOptions(key: "<<<App Key Here>>>", secret: "<<<App Secret Here>>>")
+        let networkOptions = MPNetworkOptions()
+        networkOptions.customBaseURL = URL(string: "https://rkt.example.com")
+        mParticleOptions.networkOptions = networkOptions
         
        //Please see the Identity page for more information on building this object
         let request = MPIdentityApiRequest()
@@ -182,6 +192,9 @@ Next, you'll need to start the SDK:
 
     MParticleOptions *mParticleOptions = [MParticleOptions optionsWithKey:@"REPLACE ME"
                                                                    secret:@"REPLACE ME"];
+    MPNetworkOptions *networkOptions = [MPNetworkOptions new];
+    networkOptions.customBaseURL = [NSURL URLWithString:@"https://rkt.example.com"];
+    mParticleOptions.networkOptions = networkOptions;
     
     //Please see the Identity page for more information on building this object
     MPIdentityApiRequest *request = [MPIdentityApiRequest requestWithEmptyUser];

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.mparticle:android-core:5+'
+    implementation 'com.mparticle:android-core:5.79.0'
 
     // Required for Rokt event subscription
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -70,9 +70,9 @@ flutter {
 
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
-    implementation 'com.mparticle:android-core:5+'
+    implementation 'com.mparticle:android-core:5.79.0'
 
-    implementation 'com.mparticle:android-rokt-kit:5+'
+    implementation 'com.mparticle:android-rokt-kit:5.79.0'
 
     // Required for gathering Android Advertising ID (see below)
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'

--- a/ios/mparticle_flutter_sdk.podspec
+++ b/ios/mparticle_flutter_sdk.podspec
@@ -15,8 +15,8 @@ mParticle Flutter Wrapper
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  # SDK 9.1 umbrella pod pulls required transitive dependencies.
-  s.dependency 'mParticle-Apple-SDK', '~> 9.1'
+  # SDK 9.2 umbrella pod pulls required transitive dependencies.
+  s.dependency 'mParticle-Apple-SDK', '~> 9.2'
   s.platform = :ios, '15.6'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
## Summary
- pin Android native dependencies to `com.mparticle:android-core:5.79.0` and `com.mparticle:android-rokt-kit:5.79.0` in plugin/example Gradle configs and setup docs
- bump iOS podspec dependency guidance to `mParticle-Apple-SDK ~> 9.2`
- add native CNAME initialization examples in README for Android (`NetworkOptions.withNetworkOptions`) and iOS (`MPNetworkOptions.customBaseURL`)

## Test plan
- [ ] Documentation-only verification: review `README.md`, `CHANGELOG.md`, and `ios/mparticle_flutter_sdk.podspec` for version consistency
- [ ] Android build smoke check in example app with pinned dependency versions
- [ ] iOS pod install smoke check with `mParticle-Apple-SDK ~> 9.2`